### PR TITLE
docs: add "why" CLI idea doc (v1.0.0)

### DIFF
--- a/docs/design/why-idea-04-18-2026-1.0.0.md
+++ b/docs/design/why-idea-04-18-2026-1.0.0.md
@@ -1,0 +1,907 @@
+# why — Idea Doc
+
+**Date:** 2026-04-18
+**Status:** Idea / Ready to build (priority 3 of 3)
+**Author:** Tarun Gulati + Claude
+**Version:** 1.0.0
+
+---
+
+## Table of Contents
+
+1. [The Idea](#the-idea)
+2. [Why Now](#why-now)
+3. [Target User](#target-user)
+4. [The Experience](#the-experience)
+5. [Architecture](#architecture)
+6. [Scope & Build Plan](#scope--build-plan)
+7. [CLI Interface](#cli-interface)
+8. [Git & GitHub Integration Strategy](#git--github-integration-strategy)
+9. [LLM Strategy](#llm-strategy)
+10. [Key-Commit Selection Heuristics](#key-commit-selection-heuristics)
+11. [MCP Integration](#mcp-integration)
+12. [Hard Parts](#hard-parts)
+13. [Novelty vs. Existing Tools](#novelty-vs-existing-tools)
+14. [Demo & Launch Plan](#demo--launch-plan)
+15. [Open Questions](#open-questions)
+16. [Risks](#risks)
+17. [Future Extensions](#future-extensions)
+18. [Appendix: Example Outputs](#appendix-example-outputs)
+
+---
+
+## The Idea
+
+**why** is a CLI tool that explains **why code is the way it is** by mining git history and (optionally) GitHub/GitLab pull-request context.
+
+You point it at a file, function, or line:
+
+```
+$ why src/auth/login.py:45
+```
+
+It reads the git history, follows renames, pulls commit messages, optionally fetches PR descriptions, and produces a structured explanation:
+
+- When this code first appeared (and in what context)
+- What key changes shaped it since
+- **Why it's the way it is today** — the rationale layer git blame can't show
+
+**The pitch in one line:** "git blame tells you who. `why` tells you why."
+
+**Why this matters:**
+- `git blame` shows line-level authorship but tells you nothing about *intent*
+- AI code-explainers (aider, Cursor `@file`) read the *current* state of the file but ignore history
+- Commit messages and PR descriptions contain the *why*, but nobody assembles them into a coherent explanation
+
+`why` occupies the intersection: git history + PR metadata + LLM synthesis = code rationale on demand.
+
+---
+
+## Why Now
+
+1. **LLMs can synthesize long historical context.** A function with 15 commits and 5 PRs might have 5000 tokens of context. That's trivial for 2026 context windows and cheap to process.
+
+2. **`git log` and GitHub API are stable, well-understood surfaces.** No new standards to learn; well-trodden territory.
+
+3. **Developer workflows reward "explain this gnarly code" tools.** Every tech blog post about AI dev tools includes a screenshot of someone asking Cursor to explain code. `why` is the historically-grounded version of that pattern.
+
+4. **Code archaeology is an underserved niche.** Tools like `git log --follow`, `git log -L`, and `gitk` exist, but they're low-level. Nobody wraps them with LLM synthesis for everyday use.
+
+5. **Onboarding to a new codebase is a common, painful moment.** Pairs naturally with `onboard` as "step 1: understand the shape" and `why` as "step 2: understand a specific weird bit."
+
+---
+
+## Target User
+
+**Primary:**
+- Developers opening an unfamiliar file and asking "why is this weird?"
+- Engineers debugging legacy code where the current shape is historically-imposed
+- Code reviewers trying to understand if a suspicious pattern is intentional or accidental
+- Onboarding developers who want context on specific functions
+
+**Secondary:**
+- Team historians / tech leads documenting decisions
+- Consultants auditing unfamiliar codebases
+- Writers of "how did this system evolve" retros
+
+**Explicitly not primary:**
+- Users who want general code explanations without history (use aider/Cursor)
+- Teams with pristine commit messages (they don't need LLM synthesis; git log is enough)
+
+---
+
+## The Experience
+
+### Basic use: explain a line
+
+```
+$ why src/auth/login.py:45
+
+Analyzing src/auth/login.py:45 (function: authenticate_user)
+Reading git history... 47 commits touch this file, 12 touch this function
+Fetching 5 key PR descriptions from GitHub... done
+Synthesizing... (2.1s)
+
+---
+
+# Why is src/auth/login.py:45 the way it is?
+
+## Function: authenticate_user()
+
+First appeared: 2022-03-14 (commit a3f8d2e, PR #142 "Add basic auth for v1 launch")
+
+## Key evolutions
+
+### 2022-08-09 — OAuth support (PR #298)
+The function was refactored to support both password and OAuth flows. Before
+this, it only handled username/password. The try/except on line 61 was added
+here as a workaround for OAuth providers returning malformed tokens (see the
+PR body: "Handle Google/Okta token quirks").
+
+### 2023-02-14 — Rate limiting (PR #451, incident response)
+Added after a credential-stuffing incident on Valentine's Day 2023 (see PR
+body: "Prevent credential stuffing after incident INC-0042"). The `rate_limit`
+call on line 52 has been there since. The configurable thresholds (line 48)
+were deliberately made separate for IP-based vs account-based limits.
+
+### 2024-06-03 — Session split (PR #789)
+The function used to return a session object directly. After this PR, it
+only returns a token; session creation moved to `SessionManager.create()`.
+The current signature reflects that split.
+
+## Why the current shape exists
+
+Three historical forces shape this function:
+1. **OAuth compatibility** explains the exception handling around token parsing
+2. **Post-incident hardening** explains the rate-limiting and its configurability
+3. **Session-management refactor** explains why auth returns a token, not a session
+
+## Citations
+
+- Commit a3f8d2e (2022-03-14): initial introduction
+- PR #142 (2022-03-14): "Add basic auth for v1 launch"
+- PR #298 (2022-08-09): "OAuth provider integration"
+- PR #451 (2023-02-14): "Rate limiting after INC-0042"
+- PR #789 (2024-06-03): "Session handling refactor"
+```
+
+### Function-scope analysis
+
+```
+$ why src/auth/login.py authenticate_user
+# Analyzes the whole function, not just one line
+```
+
+### Whole-file analysis
+
+```
+$ why src/auth/login.py
+# Summarizes the entire file's evolution
+```
+
+### Time-scoped analysis
+
+```
+$ why --since 2024-01-01 src/auth/login.py:45
+# Only consider history after this date
+```
+
+### Mode: concise vs deep
+
+```
+$ why --brief src/auth/login.py:45
+# One-paragraph summary only
+```
+
+```
+$ why --deep src/auth/login.py:45
+# Full history with every commit listed
+```
+
+### Without GitHub/GitLab API (git-only mode)
+
+```
+$ why --no-api src/auth/login.py:45
+# Uses only local git data; skips PR fetching
+```
+
+---
+
+## Architecture
+
+```
+User runs: why src/auth/login.py:45
+              |
+              v
+  +---------------------------------+
+  | Target resolver                 |
+  |  - parse file:line syntax       |
+  |  - resolve symbol if given      |
+  |  - validate in current repo     |
+  +------------+--------------------+
+               v
+  +---------------------------------+
+  | Git history walker              |
+  |  - git log --follow <file>      |
+  |  - git log -L <range>:<file>    |
+  |  - parse commit data            |
+  |  - follow renames               |
+  +------------+--------------------+
+               v
+  +---------------------------------+
+  | Key-commit selector             |
+  |  - score each commit            |
+  |  - keep top N (default: 5)      |
+  +------------+--------------------+
+               v
+  +---------------------------------+
+  | PR metadata fetcher             |
+  |  - detect provider (GH, GL)     |
+  |  - find PR for each key commit  |
+  |  - fetch title + body           |
+  |  - (optional, requires token)   |
+  +------------+--------------------+
+               v
+  +---------------------------------+
+  | LLM synthesizer                 |
+  |  - "given this history,         |
+  |     explain WHY"                |
+  |  - produce structured output    |
+  +------------+--------------------+
+               v
+          Formatted output
+```
+
+### Component boundaries
+
+| Component | Role | External deps |
+|-----------|------|---------------|
+| Target resolver | Parse and validate `file:line` or `file symbol` args | — |
+| Git history walker | Extract raw history | `git` binary (subprocess) |
+| Key-commit selector | Rank + prune commits | Heuristics only |
+| PR metadata fetcher | Enrich with PR data | GitHub/GitLab APIs |
+| LLM synthesizer | Compose explanation | LLM API (Anthropic/OpenAI) |
+
+Each component is independently testable. Stubbing PR fetcher enables offline tests.
+
+---
+
+## Scope & Build Plan
+
+**Total target:** ~800 LOC, ~2-3 weeks part-time.
+
+### Milestone 1: Git-only `why` (~400 LOC, week 1)
+- CLI scaffolding (Click)
+- Target resolver (file:line, file symbol, file-only)
+- Git history walker via `git log --follow` and `git log -L`
+- Commit message extraction
+- Key-commit selector (scoring: diff size, keywords, authorship)
+- LLM synthesizer (basic prompt)
+- **Deliverable:** `why <file:line>` works on any git repo, producing useful output without any API integration.
+
+### Milestone 2: PR metadata (~250 LOC, week 2)
+- GitHub API client (via `gh` CLI or direct httpx)
+- PR lookup: find PR for a given commit SHA
+- PR body fetching
+- Integrate into LLM prompt
+- Fallback behavior when token missing
+- **Deliverable:** When run on a GitHub repo, PRs are integrated into the explanation.
+
+### Milestone 3: Modes + polish (~100 LOC, week 2.5)
+- `--brief`, `--deep`, `--since`, `--no-api` flags
+- Pretty terminal output (colors, markdown rendering for TTY)
+- Error handling (non-git dirs, bad syntax, no matching history)
+- README, demo gif, PyPI publish
+- **Deliverable:** Shipped as `pip install why-cli`.
+
+### Milestone 4: MCP server mode (~50 LOC, separate week)
+- Wrap core logic as MCP server
+- `explain_line`, `explain_symbol`, `explain_file` tools
+- Test with Claude Code as MCP client
+- **Deliverable:** `why-mcp` runs as a local MCP server.
+
+### Explicitly deferred
+- GitLab API integration (v2; GitHub first)
+- Bitbucket API integration (v2)
+- Self-hosted Git services (Gitea, etc.)
+- Cross-repo history (submodules)
+- Function-level rename tracking (hard problem; uses file-level follow only in v1)
+- Historical blame (`git log -L` gives this, but visualization is complex; defer)
+
+---
+
+## CLI Interface
+
+```
+why [OPTIONS] TARGET
+
+Explain why code is the way it is, using git history.
+
+ARGUMENTS:
+  TARGET                  One of:
+                            <file>                    — explain whole file
+                            <file>:<line>             — explain line (and surrounding function)
+                            <file> <symbol>           — explain function/class by name
+
+OPTIONS:
+  --brief                 Concise one-paragraph output
+  --deep                  Full history, every commit
+  --since DATE            Only consider history after this date (YYYY-MM-DD)
+  --max-commits INT       Max commits to include in LLM context (default: 15)
+  --key-commits INT       Number of key commits to highlight (default: 5)
+  --no-api                Skip GitHub/GitLab API — use only local git data
+  --provider TEXT         Force PR provider: github | gitlab | none (default: auto)
+  --model TEXT            LLM model (default: claude-sonnet-4-6)
+  --format TEXT           Output format: markdown | text | json (default: markdown)
+  -v, --verbose           Print intermediate data (for debugging)
+  --version
+  --help
+```
+
+### Environment variables
+
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY`
+- `GITHUB_TOKEN` — for PR fetching (falls back to `gh auth token` if `gh` CLI is installed)
+- `GITLAB_TOKEN`
+- `WHY_DEFAULT_MODEL`
+
+---
+
+## Git & GitHub Integration Strategy
+
+### Git: use the `git` binary via subprocess
+
+Pro: universal, battle-tested, no library lock-in
+Con: need to parse porcelain output carefully
+
+Key commands:
+- `git log --follow --pretty=format:'<custom>' -- <file>` — commits touching the file
+- `git log -L <line_start>,<line_end>:<file>` — commits touching a specific line range
+- `git show <sha>` — full commit info including diff
+- `git blame -L <line>,<line> <file>` — who last touched each line
+- `git log --diff-filter=A --follow <file>` — when was file first added
+
+Use a porcelain format (`git log --pretty=format:'%H%n%an%n%ae%n%ai%n%s%n%b%n---'`) for reliable parsing.
+
+### GitHub: use `gh` CLI when available, else REST API
+
+**Preferred path:** `gh api repos/{owner}/{repo}/commits/{sha}/pulls` — uses user's existing auth
+**Fallback:** direct httpx to `api.github.com` with `GITHUB_TOKEN`
+
+Detecting GitHub: parse `git remote get-url origin`, match against `github.com` pattern.
+
+Cache PR data locally (~/.cache/why/) keyed by commit SHA. PRs don't change after merge; caching is safe.
+
+### GitLab: lower priority, v2
+
+Similar pattern — use `glab` CLI if available, else REST API.
+
+### Authentication graceful degradation
+
+- If `gh` is authenticated: use it
+- Else if `GITHUB_TOKEN` is set: use it
+- Else if run on public repo: try unauthenticated (rate-limited but possible)
+- Else: skip PR fetching, inform user
+
+Never block on auth. `why --no-api` always works.
+
+---
+
+## LLM Strategy
+
+### Why LLMs for this tool
+
+Without an LLM, `why` could produce:
+```
+Commit a3f8d2e (2022-03-14): Add basic auth for v1 launch
+Commit 7c9d101 (2022-08-09): OAuth provider integration
+Commit f0a923b (2023-02-14): Rate limiting after INC-0042
+```
+
+Which is useful but mechanical. The LLM's job is to synthesize the list into a *narrative*:
+- Why does this code look the way it does *now*?
+- Which historical forces are load-bearing?
+- What would a newcomer most want to know?
+
+### The prompt (sketch)
+
+```
+You are explaining WHY a piece of code exists in its current form, based on
+its git and PR history. Your audience is a developer who is looking at this
+code right now and asking "why is this weird?"
+
+Target:
+  File: {file_path}
+  Line(s): {line_range}
+  Function: {function_name}  (may be empty)
+
+Current code at target:
+```{language}
+{current_code_snippet}
+```
+
+Git history (most recent to oldest, key commits):
+{for each key commit:}
+  SHA: {short_sha}
+  Date: {date}
+  Author: {author}
+  Message:
+    {full_commit_message}
+  Diff summary:
+    +{additions} / -{deletions} lines
+  Key changes to target function:
+    {filtered_diff}
+  PR: #{pr_number} - "{pr_title}"
+    PR body:
+      {pr_body_if_available}
+
+Write an explanation structured as:
+
+## Function: {function_name}
+
+First appeared: {date} (commit {short_sha}, PR #{pr} "{pr_title}")
+
+## Key evolutions
+
+[For 3-5 key commits, in chronological order:]
+### {date} — {short_description} (PR #{pr})
+{1-3 sentences explaining what changed and why, citing the commit message or PR body}
+
+## Why the current shape exists
+
+[2-3 bullet points naming the historical forces that explain the code's shape]
+
+## Citations
+
+- [list all commits and PRs referenced]
+
+Rules:
+- Ground every claim in a specific commit or PR. If you can't cite it, don't say it.
+- If the history is sparse (few commits, no PRs), say so — don't fabricate.
+- Distinguish "inferred" from "stated." If the reason is explicit in a commit
+  message or PR body, say so. If you're inferring from diff patterns, say so.
+```
+
+### Hallucination mitigation
+
+**The #1 risk** with a history-synthesis tool is fabrication: LLM invents a reason that sounds plausible but isn't supported by the data.
+
+Mitigations:
+1. **Explicit citations required** — every claim must cite a commit or PR
+2. **Post-processing validation** — regex-check that all cited SHAs/PR numbers appear in the input context
+3. **"Sparse history" branch** — if <3 commits touch the target, output "history is too sparse for deep explanation" rather than confabulating
+4. **Distinguish stated vs inferred** — prompt forces the LLM to label its confidence
+
+### Cost
+
+Per invocation:
+- ~3-10 key commits × ~500 tokens each (commit msg + short diff) = ~5000 input tokens
+- 1-2 PR bodies × ~500 tokens = ~1000 input tokens
+- Output: ~1000-2000 tokens
+
+At Sonnet 4.6 pricing: **~$0.02-0.05 per invocation**. Trivial.
+
+---
+
+## Key-Commit Selection Heuristics
+
+Not all commits are interesting. A file touched 200 times has most commits being typo fixes, formatting, etc. We need to pick the ~5-10 commits that actually shaped the current code.
+
+### Scoring function
+
+For each commit touching the target:
+
+```python
+def score(commit):
+    s = 0
+
+    # Diff size — big changes usually matter
+    s += log(1 + commit.additions + commit.deletions) * 2
+
+    # Commit message length — more context = more intent signal
+    s += log(1 + len(commit.message)) * 1
+
+    # Keywords in message — suggests substantive change
+    keywords = ["refactor", "rewrite", "redesign", "migrate", "fix", "security",
+                "incident", "breaking", "add support", "remove", "deprecated"]
+    s += sum(2 for kw in keywords if kw.lower() in commit.message.lower())
+
+    # PR presence — PRs usually mean reviewed, intentional change
+    s += 3 if commit.has_pr else 0
+
+    # Recency bonus (recent > old, mild)
+    days_ago = (now - commit.date).days
+    s += max(0, 3 - log(1 + days_ago / 30))
+
+    # Penalize merge commits (usually not interesting)
+    s -= 5 if commit.is_merge else 0
+
+    # Penalize if message is purely typo/format/style
+    junk_patterns = ["^typo", "^fix typo", "^format", "^style:", "^lint:",
+                     "^chore:", "^bump version"]
+    if any(re.match(p, commit.message.lower()) for p in junk_patterns):
+        s -= 10
+
+    return s
+```
+
+Sort by score, take top N (default 5 for key commits, up to 15 for full context).
+
+### Always include
+
+Regardless of score:
+- The first commit (when the target was introduced) — this is the anchor
+- The most recent substantive commit (within last 90 days if any)
+
+---
+
+## MCP Integration
+
+Unlike `duck` (which is fundamentally conversational), `why` maps cleanly to MCP:
+- Input: target + options
+- Output: explanation
+- No state, no multi-turn
+
+### MCP tool surface
+
+```python
+@app.list_tools()
+async def list_tools():
+    return [
+        Tool(
+            name="explain_line",
+            description="Explain why a line of code is the way it is, using git history.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "file": {"type": "string"},
+                    "line": {"type": "integer"},
+                    "brief": {"type": "boolean", "default": False},
+                },
+                "required": ["file", "line"],
+            },
+        ),
+        Tool(
+            name="explain_symbol",
+            description="Explain the history and rationale of a function or class.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "file": {"type": "string"},
+                    "symbol": {"type": "string"},
+                },
+                "required": ["file", "symbol"],
+            },
+        ),
+        Tool(
+            name="explain_file",
+            description="Explain the evolution of an entire file.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "file": {"type": "string"},
+                },
+                "required": ["file"],
+            },
+        ),
+    ]
+```
+
+### How users add it
+
+Claude Code `~/.config/claude-code/mcp.json`:
+```json
+{
+  "mcpServers": {
+    "why": {
+      "command": "why-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+In Claude Code, users then say "why is line 45 of `src/auth/login.py` the way it is?" — Claude picks up the `explain_line` tool and uses it.
+
+### Value of MCP for `why`
+
+- User doesn't leave their AI tool to get historical context
+- The AI can integrate historical rationale into its own responses ("this is the current code, and the reason it's shaped this way is...")
+- Zero UX to build; leverages host client
+
+MCP server should be ~100-200 LOC on top of the existing library — trivial addition after milestone 1-3.
+
+---
+
+## Hard Parts
+
+### 1. Rename tracking loses context
+
+`git log --follow` handles file renames but breaks when:
+- Content was moved between files
+- A function was extracted into a new module
+- Significant refactors that changed the file's structure
+
+Mitigations:
+- Use `git log --follow --find-copies` for better coverage
+- Detect "near-misses" where the target function name appears in older file paths
+- Gracefully degrade: explain what we can, flag what we can't ("history before 2023-06 is not recoverable for this function due to a refactor")
+
+### 2. Squashed commits compress context
+
+Many projects squash-merge PRs. That means the "real" commit history is in the PR, not `git log`. Without GitHub API, squashed repos look flatter than they are.
+
+Mitigation:
+- Prioritize PR fetching when available
+- When `--no-api`, explicitly flag: "This repo uses squash merges — output would be richer with GitHub API access"
+
+### 3. PR bodies of varying quality
+
+Many PRs have one-line descriptions or none. Junk in, junk out.
+
+Mitigation:
+- Don't fabricate context — if the PR body is empty, say so
+- Score PRs by body length; deprioritize empty ones
+- For high-activity PRs with empty bodies, try fetching the PR's commit messages as a substitute
+
+### 4. Very old repositories
+
+A 10-year-old repo might have 2000 commits touching a single file. Loading them all overflows context.
+
+Mitigation:
+- Scoring function aggressively prunes low-value commits
+- `--since` flag for time-scoping
+- Hard cap on `--max-commits`
+
+### 5. Handling force-pushed history
+
+If a branch's history was force-pushed (e.g., rebased), older commits might not exist in the local clone even though they once did. `--follow` may lose thread.
+
+Mitigation:
+- If a commit referenced in a PR isn't locally visible, fetch it via GitHub API
+- Cache fetched commits locally
+
+### 6. Repos with no GitHub/GitLab
+
+Self-hosted Git, Gerrit, Phabricator, Fossil — many exist. v1 punts on these.
+
+Mitigation:
+- `--no-api` works on any git repo
+- Document supported providers clearly
+
+### 7. LLM hallucination of rationale
+
+Named as the #1 risk. The LLM might invent a plausible-sounding reason that isn't in the data.
+
+Mitigations (repeated from LLM strategy):
+- Mandatory citations
+- Post-process validation of cited SHAs/PR numbers
+- Explicit "stated vs inferred" labeling
+
+### 8. Multi-author diffs
+
+A function whose current shape came from 8 different authors is harder to narrate than one from a single author. LLM may try to attribute intent inappropriately.
+
+Mitigation:
+- Prompt explicitly: "Multiple authors touched this. Describe the collective historical forces, not individual motivations."
+
+---
+
+## Novelty vs. Existing Tools
+
+| Tool | What it does | Why `why` is different |
+|------|--------------|------------------------|
+| **`git blame`** | Who last touched each line | Tells you WHO, not WHY. `why` adds rationale. |
+| **`git log --follow`** | Full file history | Raw; no synthesis; hard to extract intent. `why` synthesizes. |
+| **`git log -L`** | Line-scoped history | Same problem as `--follow` — raw data. `why` is the LLM layer on top. |
+| **GitHub blame view + PR links** | Browser-based blame with PR hyperlinks | Manual assembly. `why` does the assembly. |
+| **`gitk` / `tig` / GitUI** | Visual history browsers | Exploration UI, not explanation. |
+| **aider / Cursor `@file`** | LLM explains current code | Ignores history. `why` is specifically history-grounded. |
+| **Sourcegraph blame + history** | Enterprise blame with context | Heavy, hosted. `why` is local and terminal-native. |
+| **GitHub Copilot "explain this PR"** | Summarize a single PR | Single-PR scope. `why` spans multiple PRs + commits for one piece of code. |
+| **Commit message / changelog generators** | Create commit messages | Write-side. `why` is read-side. |
+
+**Where `why` wins:**
+- Only tool that synthesizes multi-PR history into a narrative rationale
+- Only history-grounded AI code-explainer
+- Integrates git + GitHub + LLM in one pipeline
+- Terminal-native, local, zero-config
+
+**Where existing tools win:**
+- Raw data precision (git log beats LLM synthesis for verifiable facts)
+- Visual exploration (gitk shows the DAG, `why` just explains)
+- Cross-repo / cross-file queries (`why` is scoped to a single target)
+
+---
+
+## Demo & Launch Plan
+
+### The money demo
+
+Target: a gnarly function in a famous open-source repo.
+
+Good candidates:
+- A piece of React's reconciler (historical layers visible)
+- A Postgres planner function (20 years of history)
+- A bit of CPython's GIL code (constrained by all of Python's evolution)
+- A piece of Node.js event loop code
+
+Run `why` on it live. Show the structured output explaining historical forces.
+
+Then contrast with: what `git blame` shows for the same line. Same information — different distillation.
+
+### Launch channels
+
+- HN "Show HN: why — a tool that explains WHY code is the way it is"
+- r/git, r/programming
+- Dev-Twitter with a good one-frame screenshot
+- Mastodon/Bluesky for OSS community
+
+### Success metrics
+
+- Shipped: ✅
+- 100 stars in first week: minimum viable for an HN post
+- Someone runs it on a famous OSS repo and shares a screenshot: viral moment
+- 5+ "this explained something I'd been confused about for years" comments: real value
+- GitHub itself or a git hoster notices: jackpot
+
+---
+
+## Open Questions
+
+1. **Should `why` fetch the actual PR review comments**, not just the body? Review comments often contain rationale ("why do we need this?" "because incident X"). But they're noisy. Probably v2.
+
+2. **Should `why` support linking to GitHub Issues** referenced in commit messages ("fixes #123")? Yes — low-hanging fruit, probably v1.1.
+
+3. **Should output include a blame-like view** ("this line was last touched by X in commit Y") alongside the rationale? Maybe as a `--with-blame` flag.
+
+4. **Should `why` detect and highlight "unexplained" lines** — lines where the history has NO rationale (e.g., all commits are "fix typo")? Interesting edge-case value.
+
+5. **Should it work on uncommitted changes?** E.g., "why did I write this line I just staged?" Probably not — tool is about historical explanation, not self-reflection.
+
+6. **Should we offer a `why --author <name>` filter** — "show me only this author's history of this code"? Niche but occasionally useful.
+
+7. **Should we produce output in different tones** — "explain to a junior," "explain to a senior reviewer," "incident retrospective style"? Over-engineering for v1.
+
+8. **Could `why` eventually write a commit message** based on the diff-in-progress? Interesting crossover product but different tool.
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| **LLM fabricates rationale** | **Critical** | Mandatory citations; post-process validation of SHAs/PR numbers; "stated vs inferred" labeling |
+| **Squashed-merge repos lose context without API** | Medium | PR fetching via GitHub/GitLab; clear docs about limitation in `--no-api` mode |
+| **Function-level renames lose history** | Medium | File-level follow only in v1; flag in output when history appears to be truncated |
+| **Variable repo quality — some have great commit messages, some don't** | Medium | Tool quality is bounded by input quality. Document this; don't over-promise. |
+| **Cost scales with history depth** | Low | `--max-commits`, `--since` flags; scoring aggressively prunes |
+| **GitHub API rate limits** | Low | Use `gh` CLI's auth; cache PR data; graceful fallback |
+| **Privacy — sending private repo content + commit messages to LLM provider** | Medium | Clear disclosure in README; consider Ollama/local-model support for sensitive repos (v2) |
+
+---
+
+## Future Extensions
+
+### v2 candidates
+
+1. **GitLab + Bitbucket support** — same pattern, different APIs
+2. **Self-hosted git support** — Gerrit, Forgejo, Gitea
+3. **Function-level rename tracking** — match by signature/AST across history
+4. **Inline explanation** — `why --inline src/foo.py` prints the file with rationale comments inserted
+5. **Issue/PR cross-linking** — follow `fixes #123`, `closes #456` references for richer context
+6. **Historical blame heat-map** — visualize which lines have the most historical churn
+7. **Comparison mode** — `why compare src/foo.py:45 src/bar.py:20` — "these two lines have similar-looking code; are they historically related?"
+8. **Team mode** — pre-generate explanations for all "hot files" in a repo, serve via web UI for team onboarding
+9. **Stale-rationale detection** — flag when current code no longer reflects the historical rationale (refactor opportunity)
+
+### Crossover with other tools
+
+- **`onboard` integration:** onboard's "what to read next" section can link to `why` for confusing files
+- **`duck` integration:** duck could proactively suggest running `why` when a user is confused about code
+- **Code review integration:** a GitHub Action that runs `why` on modified files and comments on PRs
+
+### What NOT to build
+
+- A web UI (terminal-native is the point)
+- A full replacement for git blame (not the target; blame is fine for who)
+- Code generation / auto-fix based on rationale (way out of scope)
+- Historical auto-refactor suggestions (way, way out of scope)
+
+---
+
+## Appendix: Example Outputs
+
+### Example 1: A well-commented function in a mature repo
+
+```
+$ why src/database/pool.py:78
+
+## Function: acquire_connection()
+
+First appeared: 2021-11-02 (commit 4a2b81e, PR #67 "Initial connection pool")
+
+## Key evolutions
+
+### 2021-11-02 — Initial introduction (PR #67)
+Basic connection pool with LIFO semantics. 50-line initial implementation.
+Motivated by reducing connection setup overhead (see PR body: "benchmark
+showed 40% p99 improvement with pooling").
+
+### 2022-04-15 — Health check on acquire (PR #134)
+The `_ping()` call on line 83 was added here. Rationale from PR body:
+"after incident where stale connections caused 500s, validate on checkout".
+This is the source of the small latency overhead at acquisition time.
+
+### 2023-09-27 — Exponential backoff on exhaustion (PR #412)
+The backoff logic on lines 92-98 was added. Before this, the pool would
+raise immediately when exhausted. PR body: "handle transient pool pressure
+during DB failovers without hard failure".
+
+### 2024-11-08 — Configurable max_wait (PR #701)
+The `max_wait_seconds` parameter was promoted from hard-coded 30s to
+configurable. Driven by a specific team needing short waits for their
+realtime service (PR body references their internal use case).
+
+## Why the current shape exists
+
+- The pool validates on acquire because of a stale-connection incident in 2022
+- Backoff on exhaustion exists to tolerate DB failovers without hard failure
+- max_wait_seconds is configurable because different services have different
+  latency budgets
+
+## Citations
+
+- Commit 4a2b81e (2021-11-02): initial introduction
+- PR #67 (2021-11-02): "Initial connection pool"
+- PR #134 (2022-04-15): "Validate connections on acquire"
+- PR #412 (2023-09-27): "Pool exhaustion backoff"
+- PR #701 (2024-11-08): "Configurable pool wait"
+```
+
+### Example 2: A repo with sparse history
+
+```
+$ why src/utils/weird_hack.py:12
+
+## Function: normalize_timestamp()
+
+First appeared: 2023-06-14 (commit a9c31f0, no PR found — direct commit to main)
+
+## Key evolutions
+
+### 2023-06-14 — Introduction (direct commit, not via PR)
+Commit message: "fix ts". That's the entire context available.
+
+### 2024-02-03 — Comment added (direct commit to main)
+A comment was added: "# HACK: some events have timezone info, some don't".
+Commit message: "add note". No further context.
+
+## Why the current shape exists
+
+**The history is sparse.** Only 2 commits have touched this function since
+introduction, neither of which has a PR or detailed message. Inferring from
+the diff and the HACK comment:
+
+- The function handles inconsistent timezone data (stated in comment)
+- Why the inconsistency exists is not documented
+
+This function is a candidate for a deeper investigation — the history doesn't
+explain its current shape. Consider asking the original author (see blame).
+
+## Citations
+
+- Commit a9c31f0 (2023-06-14): "fix ts"
+- Commit 7e1b22a (2024-02-03): "add note"
+
+## Note
+
+No PRs were found for this function's history. Output would be richer on a
+repo with PR-reviewed history.
+```
+
+### Example 3: MCP client invocation (Claude Code session)
+
+```
+user: Why is src/auth/login.py:45 structured the way it is?
+
+Claude Code: [calls why:explain_line({file: "src/auth/login.py", line: 45})]
+
+Tool returned:
+  ... [structured output from `why`]
+
+Claude Code: The current shape of src/auth/login.py:45 is driven by three
+historical forces: OAuth compatibility (line 61's exception handling),
+post-incident rate limiting (line 52, added after a 2023 credential-stuffing
+event), and a 2024 session-management refactor that made this function
+return a token instead of a full session.
+
+In particular, the rate_limit call on line 52 is load-bearing — don't remove
+it without coordinating with the team that owns incident INC-0042's follow-up.
+```
+
+---
+
+**Ready to ticket.** When picking up this idea for ticket breakdown, invoke `/odin:tickets` against this file.
+


### PR DESCRIPTION
## Summary
- Adds `docs/design/why-idea-04-18-2026-1.0.0.md` — idea doc for **why**, a CLI that explains why code is the way it is by mining git history and PR context.
- Covers experience, architecture, CLI interface, git/GitHub strategy, LLM strategy, key-commit heuristics, MCP integration, risks, and open questions.

## Test plan
- [ ] Doc renders correctly on GitHub (TOC links, code blocks)
- [ ] Reviewers sanity-check scope, hard parts, and open questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)