### PR TITLE
feat: add defensive git subprocess wrapper

### DIFF
--- a/src/why/git.py
+++ b/src/why/git.py
@@ -1,0 +1,75 @@
+"""Thin, defensive wrapper around git subprocess calls."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+class GitError(Exception):
+    """Base exception for git subprocess failures."""
+
+
+class NotAGitRepoError(GitError):
+    """Raised when a git command is run outside any git repository."""
+
+
+class GitNotFoundError(GitError):
+    """Raised when the git binary is not on PATH."""
+
+
+class GitTimeoutError(GitError):
+    """Raised when a git command exceeds its timeout."""
+
+
+# Environment overrides applied to every git invocation to suppress interactive
+# prompts, pagers, and editors that would hang a subprocess call.
+_HARDENING_ENV = {
+    "GIT_TERMINAL_PROMPT": "0",
+    "GIT_PAGER": "cat",
+    "GIT_EDITOR": "true",
+    "LC_ALL": "C",
+}
+
+
+def run_git(args: list[str], *, cwd: Path, timeout: float = 30.0) -> str:
+    """Run ``git <args>`` in ``cwd`` and return stdout (unstripped).
+
+    Stdout is returned verbatim (trailing newline preserved). Callers that
+    want a stripped value must call ``.rstrip()`` themselves — this avoids
+    surprising binary-safe consumers later.
+
+    Raises GitNotFoundError, GitTimeoutError, NotAGitRepoError, or GitError.
+    """
+    # Layer hardening vars on top of the current environment so PATH etc. survive.
+    env = {**os.environ, **_HARDENING_ENV}
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except FileNotFoundError as e:
+        raise GitNotFoundError("git binary not found on PATH") from e
+    except subprocess.TimeoutExpired as e:
+        raise GitTimeoutError(
+            f"git {' '.join(args)} timed out after {timeout}s"
+        ) from e
+    except OSError as e:
+        # cwd not a directory, permissions, etc. — any launch-time OSError
+        # that isn't specifically "git binary missing".
+        raise GitError(f"could not launch git in {cwd}: {e}") from e
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        # Match on English stderr — LC_ALL=C in _HARDENING_ENV guarantees
+        # git emits this exact phrase regardless of the user's locale.
+        if "not a git repository" in stderr:
+            raise NotAGitRepoError(f"{cwd} is not a git repository")
+        raise GitError(f"git {' '.join(args)} failed: {stderr}")
+    return result.stdout

--- a/src/why/git.py
+++ b/src/why/git.py
@@ -23,12 +23,30 @@ class GitTimeoutError(GitError):
     """Raised when a git command exceeds its timeout."""
 
 
-# Environment overrides applied to every git invocation to suppress interactive
-# prompts, pagers, and editors that would hang a subprocess call.
+# Environment overrides applied to every git invocation. Each one closes a
+# specific way git can block a headless subprocess or drift under the user's
+# locale. See `git help environment` for the canonical reference.
 _HARDENING_ENV = {
+    # Git feature: if set to 0, git refuses to prompt on the controlling
+    # terminal for usernames/passwords (normally triggered by HTTPS remotes
+    # without a credential helper). Instead of hanging forever waiting for
+    # stdin, git exits with a "terminal prompts disabled" error we can surface.
     "GIT_TERMINAL_PROMPT": "0",
+    # Git feature: overrides `core.pager` for this invocation. Git's default
+    # pager is `less`, which can attach to a TTY and wait for the user to
+    # press `q`. Forcing `cat` makes pagination a no-op pass-through.
     "GIT_PAGER": "cat",
+    # Git feature: overrides `core.editor` for commands that would otherwise
+    # open `$EDITOR` (commit, rebase -i, tag -a). `true` is a shell builtin
+    # that exits 0 with no output, so any unexpected editor invocation
+    # returns immediately instead of blocking on vim/nano.
     "GIT_EDITOR": "true",
+    # POSIX locale override (not git-specific): forces all libc-localised
+    # output — including git's own stderr messages — to the "C" locale
+    # (ASCII English). Required because we substring-match on English
+    # phrases like "not a git repository" to classify errors; a German or
+    # Japanese user's default locale would otherwise silently break that
+    # classification.
     "LC_ALL": "C",
 }
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,186 @@
+"""Tests for the why.git subprocess wrapper."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from why.git import GitError, GitNotFoundError, GitTimeoutError, NotAGitRepoError, run_git
+
+
+def _tmp_path_is_clean(tmp_path: Path) -> bool:
+    """Return True if tmp_path is NOT inside an existing git repo."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        cwd=tmp_path, capture_output=True, text=True, check=False,
+    )
+    return result.returncode != 0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_REPO_NOT_FOUND_MSG = (
+    "fatal: not a git repository (or any of the parent directories): .git"
+)
+
+
+def _completed(
+    returncode: int, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    """Build a CompletedProcess stub with the given fields."""
+    return subprocess.CompletedProcess(
+        args=["git"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — subprocess.run is mocked
+# ---------------------------------------------------------------------------
+
+
+def test_run_git_returns_stdout_verbatim(tmp_path: Path) -> None:
+    """run_git returns stdout exactly as received, no stripping."""
+    with patch("why.git.subprocess.run", return_value=_completed(0, stdout="abc\n")) as mock_run:
+        result = run_git(["log", "--oneline"], cwd=tmp_path)
+    assert result == "abc\n"
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[0] == ["git", "log", "--oneline"]
+
+
+def test_not_a_git_repo_error(tmp_path: Path) -> None:
+    """returncode=128 + 'not a git repository' in stderr raises NotAGitRepoError."""
+    fake = _completed(128, stderr=_REPO_NOT_FOUND_MSG)
+    with (
+        patch("why.git.subprocess.run", return_value=fake),
+        pytest.raises(NotAGitRepoError, match=str(tmp_path)),
+    ):
+        run_git(["status"], cwd=tmp_path)
+
+
+def test_generic_git_error(tmp_path: Path) -> None:
+    """Non-zero returncode without repo-missing message raises GitError (not NotAGitRepoError)."""
+    fake = _completed(1, stderr="some other failure")
+    with (
+        patch("why.git.subprocess.run", return_value=fake),
+        pytest.raises(GitError) as exc_info,
+    ):
+        run_git(["status"], cwd=tmp_path)
+    # Must be base GitError, NOT the NotAGitRepoError subclass
+    assert type(exc_info.value) is GitError
+    assert "some other failure" in str(exc_info.value)
+
+
+def test_git_not_found(tmp_path: Path) -> None:
+    """FileNotFoundError from subprocess.run is translated to GitNotFoundError."""
+    with (
+        patch("why.git.subprocess.run", side_effect=FileNotFoundError),
+        pytest.raises(GitNotFoundError),
+    ):
+        run_git(["status"], cwd=tmp_path)
+
+
+def test_git_timeout(tmp_path: Path) -> None:
+    """TimeoutExpired from subprocess.run is translated to GitTimeoutError with timeout value."""
+    expired = subprocess.TimeoutExpired(cmd=["git"], timeout=30.0)
+    with (
+        patch("why.git.subprocess.run", side_effect=expired),
+        pytest.raises(GitTimeoutError, match="30"),
+    ):
+        run_git(["status"], cwd=tmp_path, timeout=30.0)
+
+
+def test_hardening_env_vars_applied(tmp_path: Path) -> None:
+    """subprocess.run is called with hardening env vars layered on top of os.environ."""
+    with patch("why.git.subprocess.run", return_value=_completed(0, stdout="")) as mock_run:
+        run_git(["status"], cwd=tmp_path)
+
+    env = mock_run.call_args.kwargs["env"]
+
+    # Hardening keys must be present with the correct values
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    assert env["GIT_PAGER"] == "cat"
+    assert env["GIT_EDITOR"] == "true"
+    assert env["LC_ALL"] == "C"
+
+    # Must be layered on top of os.environ, not a replacement — at least one real env key present
+    assert any(k in env for k in os.environ)
+
+
+def test_cwd_passed_through(tmp_path: Path) -> None:
+    """subprocess.run receives the cwd argument that was passed to run_git."""
+    with patch("why.git.subprocess.run", return_value=_completed(0, stdout="")) as mock_run:
+        run_git(["status"], cwd=tmp_path)
+
+    assert mock_run.call_args.kwargs["cwd"] == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — real git process
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """Create a minimal real git repo in tmp_path and return the path."""
+    if not _tmp_path_is_clean(tmp_path):
+        pytest.skip("tmp_path is inside an existing git repo; isolation required")
+    # fmt: off
+    subprocess.run(
+        ["git", "init", "-q"], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+    # fmt: on
+    # Write a file and make an initial commit so HEAD exists
+    (tmp_path / "README.md").write_text("hello\n")
+    subprocess.run(
+        ["git", "add", "."], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "initial"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+    return tmp_path
+
+
+def test_integration_rev_parse_head(git_repo: Path) -> None:
+    """run_git on a real repo returns a 40-char hex SHA followed by a newline."""
+    result = run_git(["rev-parse", "HEAD"], cwd=git_repo)
+    # Strip trailing newline to validate the SHA itself, but verify original is unstripped
+    sha = result.rstrip("\n")
+    assert len(sha) == 40
+    assert all(c in "0123456789abcdef" for c in sha)
+    assert result.endswith("\n")
+
+
+def test_integration_not_a_git_repo(tmp_path: Path) -> None:
+    """run_git on a plain directory raises NotAGitRepoError."""
+    if not _tmp_path_is_clean(tmp_path):
+        pytest.skip("tmp_path is inside an existing git repo; isolation required")
+    with pytest.raises(NotAGitRepoError):
+        run_git(["status"], cwd=tmp_path)
+
+
+def test_cwd_not_a_directory_raises_git_error(tmp_path: Path) -> None:
+    """If cwd is a file (not a directory), run_git wraps the OSError as GitError."""
+    not_a_dir = tmp_path / "file.txt"
+    not_a_dir.write_text("x")
+    with pytest.raises(GitError) as exc_info:
+        run_git(["status"], cwd=not_a_dir)
+    # Must be plain GitError, not a more specific subclass
+    assert type(exc_info.value) is GitError
+    assert "could not launch git" in str(exc_info.value)


### PR DESCRIPTION
## Related Links
- Closes #2
- Foundation for M1 tickets that shell out to git (log, blame, show)

## What
Adds `src/why/git.py` — a thin, defensive wrapper around
`subprocess.run(["git", ...])` — and a test suite covering both
mocked-subprocess unit paths and real-git integration paths.

Exposes:
- `run_git(args, *, cwd, timeout=30.0) -> str`
- `GitError` (base) / `NotAGitRepoError` / `GitNotFoundError` / `GitTimeoutError`

## Why
Every later M1 feature (`git log`, `git blame`, `git show`) needs git.
Centralising the subprocess plumbing means one place to get timeouts,
env hardening, error classification, and locale pinning right — instead
of duplicating it across every call site.

## How
- Layers `_HARDENING_ENV` (`GIT_TERMINAL_PROMPT=0`, `GIT_PAGER=cat`,
  `GIT_EDITOR=true`, `LC_ALL=C`) on top of `os.environ` so git cannot
  hang on prompts, pagers, or editors and always emits English stderr.
- Catches `FileNotFoundError` → `GitNotFoundError`, `TimeoutExpired` →
  `GitTimeoutError`, other `OSError` (bad cwd, permissions) → `GitError`.
- Matches the English phrase `"not a git repository"` in stderr to raise
  the specific `NotAGitRepoError` subclass.
- Returns stdout unstripped — callers `.rstrip()` as needed (keeps the
  wrapper binary-safe and avoids an implicit contract).
- `cwd` and `timeout` are keyword-only to lock the signature early.

## Test Steps
- [ ] \`pytest\` — 12 tests pass (7 mocked unit, 3 real-git integration, 2 smoke)
- [ ] \`ruff check .\` — clean
- [ ] \`mypy src\` — clean (strict)
- [ ] Integration tests auto-skip if \`tmp_path\` lives inside an existing repo

## Other Notes
- Review flagged three defer-to-later hardening ideas (SSH/proxy env
  scrubbing, \`--\` separator for user-path args, \`GIT_CONFIG_NOSYSTEM=1\`).
  None apply to M1's local-only usage; will file a follow-up
  "Harden git env for untrusted repos" when the first network-touching
  or user-path-taking caller lands.
- No caller yet — \`cli.py\` still a stub. Wiring happens in later tickets.