### PR TITLE
docs: add "Running" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ See the full design: [`docs/design/why-idea-04-18-2026-1.0.0.md`](docs/design/wh
 
 Not yet published to PyPI. For now, install from source — see Development below.
 
+## Running
+
+Once installed (see Development), `why` is available as a CLI:
+
+```bash
+why --version
+```
+
+No analysis commands yet — the CLI is a stub. See the design doc linked
+above for the planned surface.
+
 ## Development
 
 Requires Python 3.11+.
@@ -20,9 +31,20 @@ Requires Python 3.11+.
 python -m venv .venv
 source .venv/bin/activate
 pip install -e ".[dev]"
-pytest
-ruff check src tests
-mypy src
+```
+
+Run the full check suite:
+
+```bash
+pytest              # all tests
+ruff check .        # lint
+mypy src            # strict type check
+```
+
+Run a single test file while iterating:
+
+```bash
+pytest tests/test_git.py -v
 ```
 
 ## License


### PR DESCRIPTION
## Related Links
- Follow-up to #44 (git wrapper PR) — this commit was pushed after merge, so it's rolled forward as its own PR.

## What
Adds a **Running** section to `README.md` showing the only runnable CLI
surface today (\`why --version\`) and notes that analysis commands are
not implemented yet. Splits the Development section into three stanzas:
env setup, check-suite commands, and single-file test iteration.

## Why
Contributors landing on the repo after the git-wrapper merge have no
signal about what actually runs end-to-end versus what's internal
plumbing. The README documented dev tooling but not \"what does \`why\`
do right now.\" This closes that gap with one short section and a
pointer to the design doc for the full planned surface.

## How
- Insert a **Running** section between **Install** and **Development**.
- Split the Development block so setup (\`venv\` + \`pip install -e .[dev]\`)
  is separate from running checks.
- Add a one-liner for running a single test file (\`pytest tests/test_git.py -v\`)
  since that's the most common iteration loop while adding new modules.

## Test Steps
- [ ] Render README.md on GitHub — sections and code fences display correctly.
- [ ] No code changes; nothing to execute.

## Other Notes
- Docs-only. No source or test changes.