### PR TITLE
feat: Commit dataclass + porcelain log parser

### DIFF
--- a/docs/designs/2026-04-19-commit-parser-design.md
+++ b/docs/designs/2026-04-19-commit-parser-design.md
@@ -1,0 +1,162 @@
+# Commit dataclass + porcelain parser — design
+
+**Ticket:** [#3](https://github.com/tarungulati1988/why/issues/3)
+**Milestone:** M1 — Core (git-only why)
+**Depends on:** #2 (merged — `src/why/git.py` wrapper)
+**Branch:** `feat/commit-parser`
+
+---
+
+## Problem
+
+`why` synthesises explanations from git history. Everything downstream (ranking, LLM
+prompting, display) consumes a structured `Commit` object, not raw git output. We need
+a typed representation and a deterministic parser that turns `git log` porcelain text
+into `list[Commit]`.
+
+This ticket is **parser-only**. The `git log` invocation itself is a future ticket.
+
+## Goals
+
+- `Commit` dataclass with the fields listed in the ticket acceptance criteria.
+- `parse_porcelain(output: str) -> list[Commit]` that tolerates real-world messiness:
+  multi-line bodies, special chars in subjects, empty bodies, merge commits (no shortstat),
+  commits with only insertions or only deletions.
+- Fails loudly (`ValueError`) on structurally malformed input — no silent skipping.
+- mypy-strict clean, no new runtime deps.
+
+## Non-goals
+
+- Running `git log` (separate ticket).
+- Caching / persistence of parsed commits.
+- Per-file stats (`--numstat`) — only aggregate additions/deletions.
+- Byte-level handling of non-UTF-8 author names (M1 accepts stdlib `str` only).
+
+## Design
+
+### `Commit`
+
+Frozen dataclass in `src/why/commit.py`:
+
+```python
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    short_sha: str          # derived: sha[:7]
+    author_name: str
+    author_email: str
+    date: datetime          # parsed from %aI (ISO 8601 with offset)
+    subject: str
+    body: str
+    parents: tuple[str, ...]
+    additions: int = 0
+    deletions: int = 0
+
+    @property
+    def is_merge(self) -> bool:
+        return len(self.parents) > 1
+```
+
+Notes:
+- `parents` is a tuple (hashable, frozen-dataclass-friendly).
+- `short_sha` is derived in `__post_init__` via `object.__setattr__` (frozen dataclass
+  escape hatch). We don't require the caller to pass it.
+
+### Format strings
+
+```python
+PORCELAIN_FORMAT = "%H%x00%an%x00%ae%x00%aI%x00%s%x00%b%x00%P\x1e"
+SHORTSTAT_FLAG = "--shortstat"
+```
+
+Field separator `\x00` (NULL), commit separator `\x1e` (ASCII Record Separator). Two
+distinct control chars means we stay deterministic even if a commit body contains
+tabs, newlines, quotes, or other shell metacharacters.
+
+### `parse_porcelain`
+
+Pipeline:
+
+1. Split `output` on `\x1e`. The trailing empty chunk (from the final separator) is
+   dropped.
+2. For each chunk:
+   - `lstrip("\n")` — shortstat from the *previous* commit leaves a blank line before
+     the next record starts.
+   - Detect an optional trailing shortstat line via regex `r"^\s*\d+ files? changed"`.
+     If present, peel it off.
+   - Split the remaining block on `\x00`. Expect exactly 7 fields → else `ValueError`.
+   - Parse `date` via `datetime.fromisoformat` (Python 3.11 handles timezone offsets
+     natively).
+   - Parse `parents` as `tuple(seventh_field.split())`.
+   - If a shortstat line was peeled, extract insertions/deletions via one regex with
+     two optional groups (a commit can have only inserts OR only deletes).
+   - Construct `Commit`.
+
+### Why single-pass (option 1)
+
+The ticket constants `PORCELAIN_FORMAT` and `SHORTSTAT_FLAG` are designed to be used
+together in a single `git log` invocation, so shortstat is already interleaved with
+metadata in the same stdout blob. A single parser walks it once.
+
+The alternative is **option 2**: run two git commands (`git log --format=...` and
+`git log --shortstat --format=%H`), keep `parse_porcelain` metadata-only, add a
+sibling `parse_shortstat`, zip results by SHA. Simpler individual parsers, twice the
+git invocations.
+
+**When we'd refactor to option 2:** if stats ever need to come from a *different source*
+than the commit metadata. Concrete example — if we want per-file stats via
+`git diff --numstat <parent> <sha>` for renames/binary files, or stats pulled from a
+cached stats database that doesn't run git at all. At that point, metadata and stats
+diverge and the single-pass design becomes an obstacle. This rationale will be
+captured as a comment in `commit.py`.
+
+### Logging
+
+Use `logging.getLogger(__name__)`. `DEBUG` level only — parsing is a hot path and
+should be silent under normal use. Three log sites:
+
+- Start: `logger.debug("parse_porcelain: %d chunks", len(chunks))`
+- Malformed chunk (before raising): `logger.debug("malformed chunk at index %d: %r", i, chunk)`
+- End: `logger.debug("parse_porcelain: parsed %d commits (%d merges)", n, m)`
+
+No `print`. Consumers flip logging on via `logging.basicConfig(level=logging.DEBUG)`
+or a future CLI `--verbose` flag.
+
+### Error handling
+
+- Wrong field count → `ValueError` with chunk index and the received count.
+- Unparseable date → let `datetime.fromisoformat` raise `ValueError` naturally.
+- Unparseable shortstat → `ValueError` (shouldn't happen with real git output; if it
+  does, we want to see it).
+
+## Tests — `tests/test_commit.py`
+
+Unit (fixture-based):
+- Normal commit with body spanning multiple lines.
+- Merge commit (>1 parent, no shortstat line).
+- Commit with empty body.
+- Commit with special chars in subject (newlines, tabs, `|`, quotes).
+- Commit with only additions (`" 1 file changed, 5 insertions(+)"`).
+- Commit with only deletions (`" 1 file changed, 3 deletions(-)"`).
+- Malformed input (wrong field count) → `pytest.raises(ValueError)`.
+- `short_sha == sha[:7]`.
+- `is_merge` true iff `len(parents) > 1`.
+
+Integration (real git, reusing the `git_repo` fixture pattern from `test_git.py`):
+- Build a tmp repo with a normal commit + a merge commit.
+- Run `git log --format=<PORCELAIN_FORMAT> --shortstat`.
+- Feed stdout through `parse_porcelain`.
+- Assert count, SHAs round-trip, merge detection, additions/deletions match the diff.
+
+## Rollout
+
+Single PR, no feature flag. The module is unused by production code until the next
+ticket (`git log` runner) wires it in.
+
+## Risks
+
+- **Non-UTF-8 author names.** Mitigation: `str`-only input in M1; upgrade to bytes-aware
+  parsing only if/when a user reports a `UnicodeDecodeError` from `run_git`.
+- **Git version drift in shortstat wording.** The regex `r"\d+ files? changed"` is
+  stable across modern git (2.x+). If CI ever runs against an ancient git, the
+  integration test will flag it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ select = ["E", "F", "I", "UP", "B", "SIM", "RUF", "PT"]
 known-first-party = ["why"]
 
 [tool.pytest.ini_options]
-pythonpath = ["src"]
+pythonpath = ["src", "tests"]
 testpaths = ["tests"]
 
 [tool.mypy]

--- a/src/why/commit.py
+++ b/src/why/commit.py
@@ -1,0 +1,240 @@
+"""Commit dataclass and porcelain log parser for why.
+
+This module owns two things:
+1. ``Commit`` — an immutable, typed representation of a single git commit.
+2. ``parse_porcelain`` — converts raw ``git log`` output (using the constants
+   below) into ``list[Commit]``.
+
+Design note — why single-pass (option 1):
+  ``PORCELAIN_FORMAT`` and ``SHORTSTAT_FLAG`` are designed to be passed together
+  in a single ``git log`` invocation.  Because shortstat is already interleaved
+  with commit metadata in the same stdout blob, one parser can walk it in a
+  single pass — no second subprocess, no SHA-keyed merge step.
+
+  The alternative (option 2) is to run two git commands:
+    - ``git log --format=PORCELAIN_FORMAT`` for metadata only
+    - ``git log --shortstat --format=%H``   for stat lines
+  … keep each parser simple and focused, then zip the two result lists by SHA.
+
+  Concrete refactor trigger:
+    If we ever want per-file stats via ``git diff --numstat``, or stats from a
+    cached DB that doesn't call git, split metadata and stats parsing and zip
+    by SHA.  At that point the two data sources diverge and the single-pass
+    design becomes an obstacle.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, replace
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Format constants — these two constants are used together in one git call:
+#   git log --format=<PORCELAIN_FORMAT> <SHORTSTAT_FLAG>
+#
+# Field separator: NULL (\x00) — safe inside commit messages (git strips it
+# from log output anyway, but in practice subjects/bodies never contain NUL).
+# Record separator: ASCII Record Separator (\x1e) — terminates each commit so
+# shortstat lines that follow don't bleed into the next chunk.
+# ---------------------------------------------------------------------------
+
+PORCELAIN_FORMAT = "%H%x00%an%x00%ae%x00%aI%x00%s%x00%b%x00%P\x1e"
+SHORTSTAT_FLAG = "--shortstat"
+
+# Regex to identify a shortstat summary line, e.g.:
+#   " 3 files changed, 10 insertions(+), 4 deletions(-)"
+#   " 1 file changed, 5 insertions(+)"
+_SHORTSTAT_LINE_RE = re.compile(r"^\s*\d+ files? changed", re.MULTILINE)
+
+# Two optional capture groups — a commit may have only insertions OR only
+# deletions OR both.
+_STAT_RE = re.compile(r"(\d+) insertions?\(\+\)|(\d+) deletions?\(-\)")
+
+
+# ---------------------------------------------------------------------------
+# Commit dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Commit:
+    """Immutable representation of a single git commit."""
+
+    sha: str
+    author_name: str
+    author_email: str
+    date: datetime
+    subject: str
+    body: str
+    parents: tuple[str, ...]
+    additions: int = 0
+    deletions: int = 0
+
+    @property
+    def short_sha(self) -> str:
+        """First 7 hex characters of the commit SHA."""
+        return self.sha[:7]
+
+    @property
+    def is_merge(self) -> bool:
+        """True iff this commit has more than one parent (i.e. it's a merge)."""
+        return len(self.parents) > 1
+
+
+# ---------------------------------------------------------------------------
+# Parser helpers (module-level so mypy sees their signatures)
+# ---------------------------------------------------------------------------
+
+
+def _extract_stats(shortstat_text: str) -> tuple[int, int]:
+    """Return (additions, deletions) extracted from a shortstat line."""
+    additions = 0
+    deletions = 0
+    for ins_str, del_str in _STAT_RE.findall(shortstat_text):
+        if ins_str:
+            additions = int(ins_str)
+        if del_str:
+            deletions = int(del_str)
+    return additions, deletions
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def parse_porcelain(output: str) -> list[Commit]:
+    """Parse raw ``git log`` output into a list of :class:`Commit` objects.
+
+    ``output`` must be the stdout of::
+
+        git log --format=<PORCELAIN_FORMAT> --shortstat
+
+    Real git output structure when split on \\x1e (record separator):
+      chunk 0: <commit0_NUL_fields>
+      chunk 1: \\n<commit1_NUL_fields>
+      chunk 2: \\n\\n<shortstat_for_commit1>\\n<commit2_NUL_fields>
+      ...
+      chunk N: \\n\\n<shortstat_for_commit_N-1>\\n<commitN_NUL_fields>
+      chunk N+1: \\n\\n<shortstat_for_commitN>\\n   (tail, no more commit fields)
+
+    In other words the shortstat from commit K appears as a *prefix* in the
+    chunk that also contains commit K+1's NUL-delimited fields.  The tail
+    chunk (after the last commit) is shortstat-only or empty.
+
+    Pipeline:
+    1. Split on \\x1e; lstrip("\\n") each chunk.
+    2. For each chunk:
+       a. Peel an optional leading shortstat block (regex on "N files? changed").
+          This shortstat belongs to the commit parsed in the *previous* iteration.
+       b. If any NUL-delimited fields remain, parse them as the current commit.
+    3. At the end, patch the *last* built commit with the trailing shortstat
+       (from the final tail chunk, if it exists).
+
+    Raises :class:`ValueError` if any commit chunk is structurally malformed.
+    """
+    if not output:
+        return []
+
+    # Step 1: split on record separator and normalise leading newlines.
+    raw_chunks = output.split("\x1e")
+    chunks = [c.lstrip("\n") for c in raw_chunks]
+
+    logger.debug("parse_porcelain: %d chunks", len(chunks))
+
+    # pending holds the last-parsed Commit so we can patch its stats when the
+    # next chunk reveals the shortstat for it.
+    pending: Commit | None = None
+    commits: list[Commit] = []
+
+    for i, chunk in enumerate(chunks):
+        # Step 2a: peel an optional leading shortstat block.
+        # Only search the region before the first NUL — the shortstat always
+        # appears as a leading prefix before the NUL-delimited commit fields.
+        # Searching the whole chunk risks matching a body line like
+        # " 3 files changed today" as a false shortstat.
+        first_null = chunk.find("\x00")
+        search_region = chunk if first_null == -1 else chunk[:first_null]
+        shortstat_match = _SHORTSTAT_LINE_RE.search(search_region)
+        shortstat_text = ""
+        if shortstat_match:
+            # Shortstat for the *previous* commit.  Take everything up to the
+            # end of the shortstat line(s), then let the remainder be the
+            # current commit's fields.
+            #
+            # The shortstat block ends at the first line that does NOT look
+            # like stats — i.e., the first line containing a NUL byte or the
+            # start of the next commit's sha.  In practice git emits exactly
+            # one shortstat line, so we find the newline after it.
+            stat_start = shortstat_match.start()
+            # Find where the shortstat block ends: the newline terminating the
+            # summary line.  Everything after that is the next commit's fields.
+            stat_end = chunk.find("\n", stat_start)
+            if stat_end == -1:
+                # Shortstat is the entire remainder of the chunk (tail chunk).
+                shortstat_text = chunk[stat_start:]
+                chunk = chunk[:stat_start]
+            else:
+                shortstat_text = chunk[stat_start : stat_end + 1]
+                chunk = chunk[:stat_start] + chunk[stat_end + 1 :]
+
+            # Patch the previous commit's stats using dataclasses.replace —
+            # no mutable dict needed; frozen dataclass is copied with new values.
+            if pending is not None:
+                adds, dels = _extract_stats(shortstat_text)
+                pending = replace(pending, additions=adds, deletions=dels)
+
+        # Step 2b: strip residual whitespace and check for commit fields.
+        chunk = chunk.strip()
+        if not chunk:
+            # Empty or pure-shortstat chunk — no new commit to parse.
+            continue
+
+        # Flush the previous pending commit before starting a new one.
+        if pending is not None:
+            commits.append(pending)
+
+        # Split on NUL — must yield exactly 7 fields.
+        fields = chunk.split("\x00")
+        if len(fields) != 7:
+            logger.debug("malformed chunk at index %d: %r", i, chunk)
+            raise ValueError(
+                f"malformed commit chunk {i}: expected 7 fields, got {len(fields)}"
+            )
+
+        sha, author_name, author_email, date_str, subject, body, parents_str = fields
+
+        # Parse date (Python 3.11 handles ISO 8601 timezone offsets natively).
+        date = datetime.fromisoformat(date_str)
+
+        # Parents are space-separated SHAs; root commits have an empty field.
+        parents: tuple[str, ...] = tuple(parents_str.split()) if parents_str.strip() else ()
+
+        # Build the Commit with zero stats; shortstat (if any) arrives in the
+        # next chunk and will be applied via dataclasses.replace.
+        pending = Commit(
+            sha=sha,
+            author_name=author_name,
+            author_email=author_email,
+            date=date,
+            subject=subject,
+            body=body,
+            parents=parents,
+            additions=0,
+            deletions=0,
+        )
+
+    # Flush the final pending commit (its stats were already patched if the
+    # tail chunk contained a shortstat).
+    if pending is not None:
+        commits.append(pending)
+
+    n = len(commits)
+    m = sum(1 for c in commits if c.is_merge)
+    logger.debug("parse_porcelain: parsed %d commits (%d merges)", n, m)
+
+    return commits

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared test utilities for the why test suite."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _tmp_path_is_clean(tmp_path: Path) -> bool:
+    """Return True if tmp_path is NOT inside an existing git repo.
+
+    Used by integration test fixtures to skip when pytest's tmp_path
+    happens to land inside a real git working tree (e.g. the project repo
+    itself), which would invalidate isolation assumptions.
+    """
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        cwd=tmp_path, capture_output=True, text=True, check=False,
+    )
+    return result.returncode != 0

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -1,0 +1,373 @@
+"""Tests for the why.commit dataclass and porcelain parser."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from conftest import _tmp_path_is_clean
+
+from why.commit import PORCELAIN_FORMAT, SHORTSTAT_FLAG, parse_porcelain
+
+# ---------------------------------------------------------------------------
+# Helpers — build raw porcelain output strings
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(
+    sha: str = "a" * 40,
+    author_name: str = "Alice",
+    author_email: str = "alice@example.com",
+    date: str = "2024-01-15T10:30:00+00:00",
+    subject: str = "fix: resolve the thing",
+    body: str = "Detailed explanation.\n\nMore info.",
+    parents: str = "b" * 40,
+    shortstat: str = "",
+) -> str:
+    """Build a single porcelain chunk (fields joined by NUL, terminated by RS).
+
+    ``shortstat`` is appended after the RS separator, mirroring real git output
+    where --shortstat emits a blank line + stats line *after* the format block.
+    """
+    fields = "\x00".join([sha, author_name, author_email, date, subject, body, parents])
+    # The \x1e (RS) is the commit separator; shortstat appears after it on
+    # the next chunk's leading whitespace (we model the *next* chunk's prefix).
+    chunk = fields + "\x1e"
+    if shortstat:
+        chunk += shortstat
+    return chunk
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — fixture strings with \x00 and \x1e built explicitly
+# ---------------------------------------------------------------------------
+
+
+def test_parses_normal_commit() -> None:
+    """One commit with multi-line body, single parent, shortstat with additions + deletions."""
+    sha = "a" * 40
+    body = "First paragraph.\n\nSecond paragraph."
+    parent = "b" * 40
+    shortstat = "\n 3 files changed, 10 insertions(+), 4 deletions(-)\n"
+
+    # Build: <fields>\x1e\n<shortstat> — the shortstat trails after \x1e, and the
+    # next chunk would lstrip the leading \n.  We end with a trailing \x1e so the
+    # split produces a trailing empty chunk that parse_porcelain must drop.
+    output = (
+        "\x00".join([sha, "Alice", "alice@example.com", "2024-01-15T10:30:00+00:00",
+                     "fix: resolve the thing", body, parent])
+        + "\x1e"
+        + shortstat
+        + "\x1e"  # trailing separator → empty chunk
+    )
+
+    commits = parse_porcelain(output)
+    assert len(commits) == 1
+    c = commits[0]
+
+    assert c.sha == sha
+    assert c.short_sha == sha[:7]
+    assert c.author_name == "Alice"
+    assert c.author_email == "alice@example.com"
+    assert isinstance(c.date, datetime)
+    assert c.subject == "fix: resolve the thing"
+    assert c.body == body
+    assert c.parents == (parent,)
+    assert c.is_merge is False
+    assert c.additions == 10
+    assert c.deletions == 4
+
+
+def test_parses_merge_commit() -> None:
+    """Merge commit has two parents, no shortstat line. additions and deletions stay 0."""
+    sha = "c" * 40
+    parent1 = "d" * 40
+    parent2 = "e" * 40
+
+    output = (
+        "\x00".join([sha, "Bob", "bob@example.com", "2024-02-01T09:00:00+00:00",
+                     "Merge branch 'feat/x'", "", f"{parent1} {parent2}"])
+        + "\x1e"
+    )
+
+    commits = parse_porcelain(output)
+    assert len(commits) == 1
+    c = commits[0]
+
+    assert c.sha == sha
+    assert c.is_merge is True
+    assert c.parents == (parent1, parent2)
+    assert c.additions == 0
+    assert c.deletions == 0
+
+
+def test_parses_empty_body() -> None:
+    """Body field is an empty string between \x00 separators — must round-trip as ''."""
+    sha = "f" * 40
+    parent = "0" * 40
+
+    output = (
+        "\x00".join([sha, "Carol", "carol@example.com", "2024-03-10T12:00:00-05:00",
+                     "chore: bump version", "", parent])
+        + "\x1e"
+    )
+
+    commits = parse_porcelain(output)
+    assert len(commits) == 1
+    assert commits[0].body == ""
+
+
+def test_parses_special_chars_in_subject_and_body() -> None:
+    """Tabs, quotes, pipes, and a newline in body must survive parsing verbatim."""
+    sha = "1" * 40
+    parent = "2" * 40
+    subject = 'fix: handle "special" chars | tabs\there'
+    body = "line one\ttabbed\nline two with 'quotes' and | pipe"
+
+    output = (
+        "\x00".join([sha, "Dave", "dave@example.com", "2024-04-20T08:15:00+02:00",
+                     subject, body, parent])
+        + "\x1e"
+    )
+
+    commits = parse_porcelain(output)
+    assert len(commits) == 1
+    assert commits[0].subject == subject
+    assert commits[0].body == body
+
+
+def test_parses_only_insertions() -> None:
+    """Shortstat with only insertions — deletions must be 0."""
+    sha = "3" * 40
+    parent = "4" * 40
+    shortstat = "\n 1 file changed, 5 insertions(+)\n"
+
+    output = (
+        "\x00".join([sha, "Eve", "eve@example.com", "2024-05-01T00:00:00+00:00",
+                     "add: new feature", "", parent])
+        + "\x1e"
+        + shortstat
+        + "\x1e"
+    )
+
+    commits = parse_porcelain(output)
+    assert len(commits) == 1
+    assert commits[0].additions == 5
+    assert commits[0].deletions == 0
+
+
+def test_parses_only_deletions() -> None:
+    """Shortstat with only deletions — additions must be 0."""
+    sha = "5" * 40
+    parent = "6" * 40
+    shortstat = "\n 1 file changed, 3 deletions(-)\n"
+
+    output = (
+        "\x00".join([sha, "Frank", "frank@example.com", "2024-06-15T14:30:00+00:00",
+                     "remove: dead code", "", parent])
+        + "\x1e"
+        + shortstat
+        + "\x1e"
+    )
+
+    commits = parse_porcelain(output)
+    assert len(commits) == 1
+    assert commits[0].additions == 0
+    assert commits[0].deletions == 3
+
+
+def test_malformed_chunk_raises_value_error() -> None:
+    """A chunk with 5 fields instead of 7 must raise ValueError."""
+    sha = "7" * 40
+    # Only 5 fields (missing parents and body)
+    bad_output = "\x00".join([sha, "Grace", "grace@example.com", "2024-07-01T10:00:00+00:00",
+                               "bad commit"]) + "\x1e"
+
+    with pytest.raises(ValueError, match="malformed commit chunk"):
+        parse_porcelain(bad_output)
+
+
+def test_parses_multiple_commits() -> None:
+    """Two commits in one output string are both parsed correctly."""
+    sha1 = "a" * 40
+    sha2 = "b" * 40
+    parent1 = "c" * 40
+    parent2 = sha1  # second commit's parent is the first
+
+    output = (
+        "\x00".join([sha1, "Alice", "a@example.com", "2024-01-01T00:00:00+00:00",
+                     "first commit", "body one", parent1])
+        + "\x1e"
+        + "\x00".join([sha2, "Bob", "b@example.com", "2024-01-02T00:00:00+00:00",
+                       "second commit", "body two", parent2])
+        + "\x1e"
+    )
+
+    commits = parse_porcelain(output)
+    assert len(commits) == 2
+    assert commits[0].sha == sha1
+    assert commits[1].sha == sha2
+    assert commits[0].subject == "first commit"
+    assert commits[1].subject == "second commit"
+
+
+def test_empty_output_returns_empty_list() -> None:
+    """parse_porcelain('') must return an empty list, not raise."""
+    result = parse_porcelain("")
+    assert result == []
+
+
+def test_body_line_matching_shortstat_regex_is_not_misparsed() -> None:
+    """A body line that looks like a shortstat must NOT be treated as one.
+
+    The body contains '3 files changed today had this problem' — the regex
+    _SHORTSTAT_LINE_RE matches this line when searching the whole chunk, but it
+    should only search the region before the first NUL (the shortstat prefix area).
+    """
+    sha = "a" * 40
+    parent = "b" * 40
+    # Body contains a line that superficially matches the shortstat regex.
+    tricky_body = "Fixed the issue\n 3 files changed today had this problem"
+
+    output = (
+        "\x00".join([
+            sha, "Alice", "alice@example.com", "2024-01-15T10:30:00+00:00",
+            "fix: resolve the thing", tricky_body, parent,
+        ])
+        + "\x1e"
+    )
+
+    commits = parse_porcelain(output)
+    assert len(commits) == 1
+    c = commits[0]
+    # Body must round-trip verbatim — no false shortstat extraction.
+    assert c.body == tricky_body
+    # No stats should have been detected.
+    assert c.additions == 0
+    assert c.deletions == 0
+
+
+def test_parses_root_commit() -> None:
+    """A root commit has an empty parents field — parents must be () and is_merge False."""
+    sha = "9" * 40
+
+    output = (
+        "\x00".join([
+            sha, "Alice", "alice@example.com", "2024-01-01T00:00:00+00:00",
+            "initial commit", "", "",  # empty parents field
+        ])
+        + "\x1e"
+    )
+
+    commits = parse_porcelain(output)
+    assert len(commits) == 1
+    c = commits[0]
+    assert c.parents == ()
+    assert c.is_merge is False
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — real git process
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """Create a minimal real git repo in tmp_path and return the path.
+
+    Layout:
+      - initial commit (adds file.txt with 5 lines)
+      - edit commit on main (modifies file.txt — adds + removes lines)
+      - feature branch created from initial, then merged into main (merge commit)
+    """
+    if not _tmp_path_is_clean(tmp_path):
+        pytest.skip("tmp_path is inside an existing git repo; isolation required")
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    git("init", "-q")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test User")
+
+    # Initial commit: add a file with content
+    (tmp_path / "file.txt").write_text("line1\nline2\nline3\nline4\nline5\n")
+    git("add", ".")
+    git("commit", "--quiet", "-m", "initial: add file.txt")
+
+    # Detect the default branch name (git >= 2.28 uses "main" when configured,
+    # older versions default to "master"). We capture stdout to read it back.
+    default_branch = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=tmp_path, check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+    # Feature branch: branch off initial, add a new file
+    git("checkout", "-q", "-b", "feat/branch")
+    (tmp_path / "feature.txt").write_text("feature content\n")
+    git("add", ".")
+    git("commit", "--quiet", "-m", "feat: add feature.txt")
+
+    # Back to the default branch, make an edit commit that adds and removes lines
+    git("checkout", "-q", default_branch)
+    (tmp_path / "file.txt").write_text("line1\nline2\nline3\nLINE4_EDITED\nline5\nextra\n")
+    git("add", ".")
+    git("commit", "--quiet", "-m", "edit: modify file.txt")
+
+    # Merge the feature branch — creates a merge commit
+    git("merge", "--no-ff", "--quiet", "-m", "Merge branch 'feat/branch'", "feat/branch")
+
+    return tmp_path
+
+
+def test_integration_round_trip(git_repo: Path) -> None:
+    """Full round-trip: real git log → parse_porcelain → structured Commit objects.
+
+    Asserts:
+    - Correct commit count (4: merge + edit + feat + initial)
+    - Exactly one merge commit
+    - SHAs match git rev-list HEAD
+    - The edit commit has nonzero additions and deletions
+    """
+    # Run git log with the porcelain format + shortstat
+    result = subprocess.run(
+        ["git", "log", f"--format={PORCELAIN_FORMAT}", SHORTSTAT_FLAG],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    raw = result.stdout
+
+    commits = parse_porcelain(raw)
+
+    # Verify count: merge, edit, feat, initial = 4 commits
+    assert len(commits) == 4
+
+    # Get the canonical SHA order from git rev-list
+    rev_list = subprocess.run(
+        ["git", "rev-list", "HEAD"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    expected_shas = rev_list.stdout.strip().splitlines()
+    parsed_shas = [c.sha for c in commits]
+    assert parsed_shas == expected_shas
+
+    # Exactly one merge commit
+    merge_commits = [c for c in commits if c.is_merge]
+    assert len(merge_commits) == 1
+
+    # Find the edit commit by subject
+    edit_commit = next(c for c in commits if "edit" in c.subject)
+    assert edit_commit.additions > 0
+    assert edit_commit.deletions > 0
+
+    # short_sha is correct for all commits
+    for c in commits:
+        assert c.short_sha == c.sha[:7]
+        assert isinstance(c.date, datetime)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -8,17 +8,9 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from conftest import _tmp_path_is_clean
 
 from why.git import GitError, GitNotFoundError, GitTimeoutError, NotAGitRepoError, run_git
-
-
-def _tmp_path_is_clean(tmp_path: Path) -> bool:
-    """Return True if tmp_path is NOT inside an existing git repo."""
-    result = subprocess.run(
-        ["git", "rev-parse", "--git-dir"],
-        cwd=tmp_path, capture_output=True, text=True, check=False,
-    )
-    return result.returncode != 0
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Related Links
- Ticket: https://github.com/tarungulati1988/why/issues/3
- Design: `docs/designs/2026-04-19-commit-parser-design.md`

## What
- New `Commit` frozen dataclass in `src/why/commit.py` (sha, short_sha, author_name, author_email, date, subject, body, parents, additions, deletions, `is_merge` property).
- New `parse_porcelain(output) -> list[Commit]` — single-pass parser for `git log --format=<PORCELAIN_FORMAT> --shortstat` output.
- Module constants `PORCELAIN_FORMAT` and `SHORTSTAT_FLAG` for callers to share one source of truth for the git format string.
- 11 unit tests + 1 integration test (real git repo). Shared `_tmp_path_is_clean` helper extracted to `tests/conftest.py`.

## Why
- Every downstream consumer (ranking, LLM prompting, display) needs structured commits, not raw text. This ticket establishes the canonical typed representation and the parser that produces it.
- Field separator `\x00` + record separator `\x1e` together keep the parse deterministic even when commit bodies contain newlines, tabs, quotes, or other shell metacharacters.

## How
- **Single-pass parser (option 1):** because `PORCELAIN_FORMAT` and `--shortstat` are used together in one `git log` call, metadata and stats arrive interleaved. One parser walks them in a single pass using a `pending: Commit | None` slot and `dataclasses.replace` to patch stats when the next chunk's shortstat is peeled.
- **Shortstat detection is scoped to the pre-NUL region of each chunk.** This fixes a subtle bug (caught during review) where a commit body line like `" 3 files changed today"` would be misidentified as a shortstat. The sha — first field after the shortstat prefix — is hex-only and can never match the regex.
- **Option 2 (two git calls, zip by SHA) is documented in `commit.py` as a future refactor trigger** for when stats ever need to come from a different source than metadata (e.g. per-file stats via `git diff --numstat`, or a cached stats DB).
- `short_sha` is a `@property` returning `sha[:7]` — simpler than a stored field + `__post_init__` override.
- Debug-level `logging` only (no `print`); silent under normal use.

## Test Steps
- [ ] `pytest -v` — all 24 tests pass.
- [ ] `mypy src/` — strict mode, no issues.
- [ ] `ruff check src/ tests/` — clean.
- [ ] Integration test (`test_integration_round_trip`) builds a real git repo with a merge commit and verifies round-trip parsing.

## Other Notes
- **Out of scope:** the `git log` subprocess runner. This ticket is parser-only; the runner is a future ticket.
- **Trust boundary documented:** `parse_porcelain` must only be called on unmodified stdout of `git log` with `PORCELAIN_FORMAT`. A hand-crafted `\x1e` byte in a commit body could mis-chunk input from untrusted repos; for the current single-user local-CLI use case this is acceptable.
- **Reviewer findings resolved:** 5/5 blocking or major (shortstat-in-body regex scope, `dict[str, object]` indirection + type-ignores, `short_sha` complexity, root-commit coverage, `_tmp_path_is_clean` dedup).