### PR TITLE
feat: add Target resolver (#4)

### DIFF
--- a/src/why/target.py
+++ b/src/why/target.py
@@ -48,8 +48,8 @@ def parse_target(
 
     try:
         resolved.relative_to(repo_root)
-    except ValueError:
-        raise TargetError(f"path escapes repository root: {resolved}")
+    except ValueError as e:
+        raise TargetError(f"path escapes repository root: {resolved}") from e
 
     if not resolved.exists():
         raise TargetError(f"file not found: {resolved}")

--- a/src/why/target.py
+++ b/src/why/target.py
@@ -1,0 +1,76 @@
+"""Target resolver for the why CLI.
+
+A Target is the thing the user points why at: a file, optionally narrowed
+to a line number or a symbol name.  This module is a pure domain module —
+no I/O beyond resolving the path, no Click, no subprocess.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Target:
+    file: Path
+    line: int | None = None
+    symbol: str | None = None
+
+
+class TargetError(Exception): ...
+
+
+def parse_target(
+    spec: str,
+    extra: str | None = None,
+    repo: Path | None = None,
+) -> Target:
+    """Resolve a user-supplied spec string into a :class:`Target`.
+
+    ``spec`` follows the form ``<path>[:<line>]``.
+    ``extra`` is an optional positional symbol name from the CLI.
+    ``repo`` is the root used to resolve relative paths (defaults to CWD at call time).
+    """
+    repo = repo if repo is not None else Path.cwd()
+
+    line: int | None = None
+    symbol: str | None = None
+    suffix: str | None = None
+
+    if ":" in spec:
+        path_part, suffix = spec.rsplit(":", 1)
+    else:
+        path_part = spec
+
+    repo_root = repo.resolve()
+    resolved = (repo_root / path_part).resolve()
+
+    try:
+        resolved.relative_to(repo_root)
+    except ValueError:
+        raise TargetError(f"path escapes repository root: {resolved}")
+
+    if not resolved.exists():
+        raise TargetError(f"file not found: {resolved}")
+
+    if suffix is not None:
+        if extra is not None:
+            raise TargetError(
+                f"ambiguous: both '{spec}' (contains ':') and extra='{extra}' supplied"
+            )
+
+        try:
+            line = int(suffix)
+        except ValueError as e:
+            raise TargetError(
+                f"line number must be an integer, got '{suffix}'"
+            ) from e
+
+        if line < 1:
+            raise TargetError(f"line number must be >= 1, got {line}")
+
+    elif extra is not None:
+        symbol = extra
+
+    return Target(file=resolved, line=line, symbol=symbol)

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -6,10 +6,10 @@ from pathlib import Path
 
 import pytest
 
-from why.target import Target, TargetError, parse_target
+from why.target import TargetError, parse_target
 
 
-@pytest.fixture()
+@pytest.fixture
 def tmp_repo(tmp_path: Path) -> Path:
     """Create a minimal repo layout with a real file for path resolution."""
     src = tmp_path / "src"

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,0 +1,72 @@
+"""Tests for the Target resolver (src/why/target.py)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from why.target import Target, TargetError, parse_target
+
+
+@pytest.fixture()
+def tmp_repo(tmp_path: Path) -> Path:
+    """Create a minimal repo layout with a real file for path resolution."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "foo.py").write_text("# placeholder\n")
+    return tmp_path
+
+
+class TestParseTargetLineNumber:
+    def test_colon_with_integer_suffix_sets_line(self, tmp_repo: Path) -> None:
+        t = parse_target("src/foo.py:45", repo=tmp_repo)
+        assert t.line == 45
+        assert t.symbol is None
+        assert t.file == (tmp_repo / "src/foo.py").resolve()
+
+    def test_colon_with_non_integer_suffix_raises(self, tmp_repo: Path) -> None:
+        with pytest.raises(TargetError, match="must be an integer"):
+            parse_target("src/foo.py:notanumber", repo=tmp_repo)
+
+    def test_line_zero_raises(self, tmp_repo: Path) -> None:
+        with pytest.raises(TargetError, match=">="):
+            parse_target("src/foo.py:0", repo=tmp_repo)
+
+    def test_negative_line_raises(self, tmp_repo: Path) -> None:
+        with pytest.raises(TargetError, match=">="):
+            parse_target("src/foo.py:-1", repo=tmp_repo)
+
+
+class TestParseTargetSymbol:
+    def test_extra_arg_sets_symbol(self, tmp_repo: Path) -> None:
+        t = parse_target("src/foo.py", "my_func", repo=tmp_repo)
+        assert t.symbol == "my_func"
+        assert t.line is None
+        assert t.file == (tmp_repo / "src/foo.py").resolve()
+
+
+class TestParseTargetNoLineNoSymbol:
+    def test_bare_path_returns_target_with_no_line_no_symbol(self, tmp_repo: Path) -> None:
+        t = parse_target("src/foo.py", repo=tmp_repo)
+        assert t.line is None
+        assert t.symbol is None
+        assert t.file == (tmp_repo / "src/foo.py").resolve()
+
+
+class TestParseTargetAmbiguous:
+    def test_colon_spec_with_extra_raises_target_error(self, tmp_repo: Path) -> None:
+        with pytest.raises(TargetError, match="ambiguous"):
+            parse_target("src/foo.py:45", "my_func", repo=tmp_repo)
+
+
+class TestParseTargetMissingFile:
+    def test_nonexistent_file_raises_target_error(self, tmp_repo: Path) -> None:
+        with pytest.raises(TargetError, match="file not found"):
+            parse_target("missing.py", repo=tmp_repo)
+
+
+class TestParseTargetTraversal:
+    def test_dotdot_traversal_raises(self, tmp_repo: Path) -> None:
+        with pytest.raises(TargetError, match="escapes repository root"):
+            parse_target("../../etc/passwd", repo=tmp_repo)


### PR DESCRIPTION
## Related Links
- Closes #4
- Depends on #1

## What
New module `src/why/target.py` — `Target` dataclass, `TargetError`, and `parse_target()` that resolves a user-supplied CLI spec into a typed, validated target.

## Why
M1 (Core) milestone requires a target resolver before any git-blame or LLM pipeline work can begin. `parse_target` is the front door for all user input.

## How
- Supports three input forms: `file`, `file:line`, `file symbol`
- Check order: split → path confinement → file existence → ambiguity → line parse
- Path traversal guard (`../../etc/passwd` raises `TargetError`)
- Line number must be ≥ 1
- `repo` defaults to `Path.cwd()` at call time (not import time)
- Pure domain module — no Click dependency

## Test Steps
```
python -m pytest tests/test_target.py -v   # 9 tests
python -m pytest                            # 33 tests, no regressions
```

## Other Notes
- `TargetError` is a bare `Exception` subclass — CLI layer catches it and re-raises as `click.UsageError`
- Exception cause chain preserved via `raise ... from e`