### PR TITLE
feat: add find_introduction to detect first-appeared commit

### DIFF
--- a/src/why/history.py
+++ b/src/why/history.py
@@ -1,8 +1,8 @@
 """File commit history retrieval for the why CLI.
 
-This module provides ``get_file_history`` and ``get_line_history``: thin
-orchestration layers that build git invocations and delegate parsing to
-``parse_porcelain``.
+This module provides ``get_file_history``, ``get_line_history``, and
+``find_introduction``: thin orchestration layers that build git invocations
+and delegate parsing to ``parse_porcelain``.
 
 Design note — why relative paths are not normalised here:
   ``target.py`` always resolves paths to absolute before they reach this
@@ -103,3 +103,44 @@ def get_line_history(file: Path, repo: Path, *, line: int) -> list[Commit]:
             return []
         raise
     return parse_porcelain(output)
+
+
+def find_introduction(file: Path, repo: Path) -> Commit | None:
+    """Return the oldest commit that first introduced ``file`` into the repo.
+
+    Uses ``--diff-filter=A --follow`` to find the commit that added the file,
+    traversing renames so the original introduction is found even if the file
+    was later renamed.
+
+    Args:
+        file: Absolute path to the file whose introduction commit is requested.
+        repo: Root of the git repository (used as the cwd for git).
+
+    Returns:
+        The oldest :class:`Commit` that added ``file``, or ``None`` if the
+        file has no git history (e.g., untracked or never committed).
+    """
+    # NOTE: enhancement opportunity — path-confinement guard
+    # If callers ever bypass Target resolution and pass untrusted paths directly,
+    # add a guard here similar to get_line_history:
+    #   resolved = file.resolve()
+    #   repo_resolved = repo.resolve()
+    #   if not resolved.is_relative_to(repo_resolved):
+    #       raise ValueError(f"file {file} escapes repository root {repo}")
+    # At that point also pass str(resolved) instead of str(file).
+    args = [
+        "log",
+        "--diff-filter=A",
+        "--follow",
+        f"--format={PORCELAIN_FORMAT}",
+        "--",
+        str(file),
+    ]
+    output = run_git(args, cwd=repo)
+    if not output.strip():
+        return None
+    commits = parse_porcelain(output)
+    # parse_porcelain returns newest-first. --diff-filter=A --follow normally
+    # yields exactly 1 commit, but a file deleted and re-added has multiple add
+    # events. commits[-1] always returns the oldest (the true introduction).
+    return commits[-1] if commits else None

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,4 +1,4 @@
-"""Tests for why.history: get_file_history and get_line_history."""
+"""Tests for why.history: get_file_history, get_line_history, and find_introduction."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ import pytest
 from conftest import _tmp_path_is_clean, make_git_runner
 
 from why.git import GitError
-from why.history import get_file_history, get_line_history
+from why.history import find_introduction, get_file_history, get_line_history
 
 # ---------------------------------------------------------------------------
 # Unit tests — run_git and parse_porcelain are mocked
@@ -346,3 +346,93 @@ class TestLineHistoryIntegration:
         )
         assert commits[0].subject == "C: finalize line 1"
         assert commits[2].subject == "A: create foo.py"
+
+
+# ---------------------------------------------------------------------------
+# find_introduction — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFindIntroductionArgs:
+    """Verify find_introduction builds the correct git args."""
+
+    def test_args_contain_diff_filter_A(self) -> None:
+        """--diff-filter=A must appear in args forwarded to run_git."""
+        fake_repo = Path("/fake/repo")
+        target_file = fake_repo / "foo.py"
+
+        with (
+            patch("why.history.run_git", return_value="raw") as mock_run_git,
+            patch("why.history.parse_porcelain", return_value=[MagicMock()]),
+        ):
+            find_introduction(target_file, fake_repo)
+
+        args_passed = mock_run_git.call_args.args[0]
+        assert "--diff-filter=A" in args_passed
+
+    def test_args_contain_follow(self) -> None:
+        """--follow must appear in args."""
+        fake_repo = Path("/fake/repo")
+        target_file = fake_repo / "foo.py"
+
+        with (
+            patch("why.history.run_git", return_value="raw") as mock_run_git,
+            patch("why.history.parse_porcelain", return_value=[MagicMock()]),
+        ):
+            find_introduction(target_file, fake_repo)
+
+        args_passed = mock_run_git.call_args.args[0]
+        assert "--follow" in args_passed
+
+    def test_empty_output_returns_none(self) -> None:
+        """Empty git output must return None without calling parse_porcelain."""
+        fake_repo = Path("/fake/repo")
+        target_file = fake_repo / "foo.py"
+
+        with (
+            patch("why.history.run_git", return_value="  "),
+            patch("why.history.parse_porcelain") as mock_parse,
+        ):
+            result = find_introduction(target_file, fake_repo)
+
+        assert result is None
+        mock_parse.assert_not_called()
+
+    def test_returns_oldest_commit_when_multiple_returned(self) -> None:
+        """When parse_porcelain returns multiple commits, the oldest (last) is returned."""
+        fake_repo = Path("/fake/repo")
+        target_file = fake_repo / "foo.py"
+        older = MagicMock(name="older_commit")
+        newer = MagicMock(name="newer_commit")
+        # parse_porcelain returns newest-first, so newer is index 0, older is index -1
+        mock_commits = [newer, older]
+
+        with (
+            patch("why.history.run_git", return_value="raw"),
+            patch("why.history.parse_porcelain", return_value=mock_commits),
+        ):
+            result = find_introduction(target_file, fake_repo)
+
+        assert result is older
+
+
+# ---------------------------------------------------------------------------
+# find_introduction — integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestFindIntroductionIntegration:
+    """Integration: find_introduction runs real git and identifies the correct commit."""
+
+    def test_introduction_of_renamed_file_is_commit_A(self, renamed_repo: Path) -> None:
+        """new_name.py was introduced as old_name.py in commit A — must return commit A."""
+        # renamed_repo history: A creates old_name.py, B renames it to new_name.py, C edits it
+        commit = find_introduction(renamed_repo / "new_name.py", renamed_repo)
+        assert commit is not None
+        assert commit.subject == "A: create old_name.py and other.py"
+
+    def test_untracked_file_returns_none(self, renamed_repo: Path) -> None:
+        """A file with no git history must return None."""
+        ghost = renamed_repo / "never_committed.py"
+        result = find_introduction(ghost, renamed_repo)
+        assert result is None


### PR DESCRIPTION
## Related Links
- Closes #7
- Depends on #5 (get_file_history)

## What
Adds `find_introduction(file: Path, repo: Path) -> Commit | None` to `src/why/history.py`. Given any file path, it returns the oldest commit that first introduced the file into the repository — traversing renames via `--diff-filter=A --follow` so the original add event is found even when the file was later renamed.

## Why
This is the anchor commit that the `why` explanation output will use — the "this was first written in commit X" fact. Without it, downstream synthesis has no introduction point to reason from.

## How
- `git log --diff-filter=A --follow --format=<PORCELAIN_FORMAT> -- <file>` — no shortstat (stats aren't needed for an introduction lookup)
- `commits[-1]` picks the oldest from the newest-first `parse_porcelain` result; handles the edge case where a file was deleted and re-added (multiple add events)
- Returns `None` for untracked files (empty git output)
- No path-confinement guard at this layer (handled upstream by `Target`); a `# NOTE:` block documents how to add it if call sites ever bypass `Target`

## Test Steps
- [ ] `pytest tests/test_history.py -v` — 24 tests, all green
- [ ] `pytest` — 57 tests total, no regressions
- Unit: args contain `--diff-filter=A`, `--follow`; empty output → `None` without calling `parse_porcelain`; multiple-commit mock returns `commits[-1]` (oldest)
- Integration (reuses `renamed_repo` fixture): `find_introduction(new_name.py)` resolves to commit A (original add of `old_name.py`); untracked file → `None`

## Other Notes
- Return annotation is bare `Commit | None` (not quoted) — `from __future__ import annotations` handles lazy evaluation, consistent with sibling functions
- Enhancement opportunity comment (path-confinement guard pseudocode) lives as a `# NOTE:` block inside the function body, not in the docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)