### PR TITLE
feat: add get_commit_diff for targeted diff extraction

### DIFF
--- a/docs/designs/2026-04-24-diff-extraction-design.md
+++ b/docs/designs/2026-04-24-diff-extraction-design.md
@@ -1,0 +1,108 @@
+# Design: Diff Extraction for Target Scope (Issue #11)
+
+**Date:** 2026-04-24
+**Milestone:** M1 - Core (git-only why)
+**Depends on:** #2 (run_git wrapper — already shipped)
+
+---
+
+## Problem
+
+The LLM pipeline needs the concrete text of what changed in a commit, not just the commit message. For symbol-scoped queries (e.g. "why did this function change?") we want a diff scoped to a specific file and optionally a line range, so we don't flood the context window with unrelated changes.
+
+---
+
+## Interface
+
+```python
+# src/why/diff.py
+
+def get_commit_diff(
+    sha: str,
+    file: Path,
+    line_range: tuple[int, int] | None,
+    repo: Path,
+    max_chars: int = 2000,
+) -> str:
+```
+
+- Returns a raw diff string (unified diff format).
+- Truncates output > `max_chars` with `"\n... [truncated]"` appended.
+- Raises `GitError` (or subclass) on git failures that aren't gracefully handled.
+
+---
+
+## Approach: Two git commands, one per mode
+
+### Whole-file mode (`line_range=None`)
+
+```
+git show --format= <sha> -- <file>
+```
+
+- `--format=` suppresses the commit header; stdout is pure unified diff.
+- Returns the full file patch for that commit.
+
+### Line-range mode (`line_range=(start, end)`)
+
+```
+git log -L <start>,<end>:<file> <sha>^!
+```
+
+- `git log -L` tracks the specified line range through history, showing exactly what changed in those lines for this commit.
+- `<sha>^!` is shorthand for `<sha>^..<sha>` — limits output to this single commit vs its parent.
+- Semantically correct: git tracks the range even if lines moved due to earlier insertions/deletions.
+
+### Root commit fallback
+
+`git log -L ... <sha>^!` fails when `sha` has no parent (root commit). In that case, fall back to `git show --format= <sha> -- <file>` (whole-file mode), ignoring `line_range`. Root commits always show all lines as additions, so the LLM still gets meaningful context.
+
+**Detection:** Check if `git rev-parse <sha>^` exits non-zero, OR catch the `GitError` from the failing `git log -L` call and re-run as whole-file. The catch-and-retry approach avoids an extra subprocess for the common case.
+
+---
+
+## Truncation
+
+After the git command succeeds:
+
+```python
+if len(output) > max_chars:
+    output = output[:max_chars] + "\n... [truncated]"
+```
+
+Simple character-count truncation. Mid-hunk truncation is acceptable — callers are LLMs, not diff processors.
+
+---
+
+## Module structure
+
+```
+src/why/diff.py        # new module
+tests/test_diff.py     # new test file
+```
+
+No changes to existing modules. `diff.py` imports only `run_git` from `why.git`.
+
+---
+
+## Tests
+
+**Unit (mocked `run_git`):**
+- Whole-file mode builds correct `git show` args
+- Line-range mode builds correct `git log -L` args
+- Truncation at exactly `max_chars` characters
+- Truncation appends `"\n... [truncated]"`
+- Output shorter than `max_chars` is returned verbatim
+
+**Integration (real git repo via `make_git_runner` from `conftest`):**
+- Known commit + known file → diff string contains expected `+`/`-` lines
+- Line-range on a known commit → diff contains only the changed lines in range
+- Root commit fallback → returns a non-empty diff without error
+
+---
+
+## What this is NOT
+
+- No caching — callers decide whether to cache.
+- No multi-file diffs — `file` is always a single `Path`.
+- No binary file handling — git returns a binary notice string; that's fine.

--- a/src/why/diff.py
+++ b/src/why/diff.py
@@ -1,0 +1,73 @@
+"""Utilities for retrieving a commit's diff from a git repository."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from why.git import GitError, run_git
+
+
+def get_commit_diff(
+    sha: str,
+    file: Path,
+    line_range: tuple[int, int] | None,
+    repo: Path,
+    max_chars: int = 2000,
+) -> str:
+    """Return the diff for *sha* scoped to *file*, optionally narrowed to *line_range*.
+
+    Parameters
+    ----------
+    sha:
+        The commit SHA to inspect.
+    file:
+        Path to the file (relative to *repo*) whose diff is wanted.
+    line_range:
+        Optional ``(start, end)`` tuple (1-based, inclusive). When supplied the
+        function uses ``git log -L`` to track the exact line range; otherwise the
+        full file diff from ``git show`` is returned.
+    repo:
+        Absolute path to the git repository root used as cwd for every subprocess.
+    max_chars:
+        Maximum number of characters to return. Output longer than this is
+        truncated and a ``"\\n... [truncated]"`` suffix is appended.
+
+    Returns
+    -------
+    str
+        The (possibly truncated) diff text.
+    """
+    if line_range is not None:
+        start, end = line_range
+        # Use git log -L to track the line range semantically within a single
+        # commit. `sha^!` is shorthand for `sha^..sha` (scopes to one commit).
+        log_args = [
+            "log",
+            "-L",
+            f"{start},{end}:{file}",  # range spec: <start>,<end>:<path>
+            f"{sha}^!",
+        ]
+        try:
+            output = run_git(log_args, cwd=repo)
+        except GitError as exc:
+            # Only the base GitError (non-zero exit) signals a root-commit
+            # failure (no parent for sha^!). Subclasses like GitTimeoutError or
+            # GitNotFoundError indicate a different problem and must propagate.
+            if type(exc) is not GitError:
+                raise
+            output = _whole_file_diff(sha, file, repo)
+    else:
+        output = _whole_file_diff(sha, file, repo)
+
+    # Truncate long output so callers receive a bounded string.
+    if len(output) > max_chars:
+        output = output[:max_chars] + "\n... [truncated]"
+
+    return output
+
+
+def _whole_file_diff(sha: str, file: Path, repo: Path) -> str:
+    """Run ``git show --format= <sha> -- <file>`` and return raw unified diff."""
+    # --format= suppresses the commit header so only the patch is emitted.
+    args = ["show", "--format=", sha, "--", str(file)]
+    return run_git(args, cwd=repo)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -91,9 +91,11 @@ def test_root_commit_fallback_on_git_error(tmp_path: Path) -> None:
 
 def test_git_error_subclass_propagates_from_line_range_mode(tmp_path: Path) -> None:
     """GitError subclasses (e.g. GitTimeoutError) on the -L path must not be swallowed."""
-    with patch("why.diff.run_git", side_effect=GitTimeoutError("timed out")):
-        with pytest.raises(GitTimeoutError):
-            get_commit_diff("abc1234", Path("f.py"), line_range=(1, 5), repo=tmp_path)
+    with (
+        patch("why.diff.run_git", side_effect=GitTimeoutError("timed out")),
+        pytest.raises(GitTimeoutError),
+    ):
+        get_commit_diff("abc1234", Path("f.py"), line_range=(1, 5), repo=tmp_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,186 @@
+"""Tests for why.diff.get_commit_diff."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import call, patch
+
+import pytest
+from conftest import _tmp_path_is_clean, make_git_runner
+
+from why.diff import get_commit_diff
+from why.git import GitError, GitTimeoutError
+
+# ---------------------------------------------------------------------------
+# Unit tests — why.diff.run_git is mocked
+# ---------------------------------------------------------------------------
+
+
+def test_whole_file_mode_passes_correct_args(tmp_path: Path) -> None:
+    """Whole-file mode (line_range=None) calls git show with the expected args."""
+    sha = "abc1234"
+    file = Path("path/to/file.py")
+    expected_args = ["show", "--format=", sha, "--", str(file)]
+
+    with patch("why.diff.run_git", return_value="diff output\n") as mock_run_git:
+        get_commit_diff(sha=sha, file=file, line_range=None, repo=tmp_path)
+
+    mock_run_git.assert_called_once_with(expected_args, cwd=tmp_path)
+
+
+def test_line_range_mode_passes_correct_args(tmp_path: Path) -> None:
+    """Line-range mode calls git log -L with the correct range and sha^! args."""
+    sha = "abc1234"
+    file = Path("path/to/file.py")
+    line_range = (5, 10)
+    expected_args = ["log", "-L", "5,10:path/to/file.py", "abc1234^!"]
+
+    with patch("why.diff.run_git", return_value="diff output\n") as mock_run_git:
+        get_commit_diff(sha=sha, file=file, line_range=line_range, repo=tmp_path)
+
+    mock_run_git.assert_called_once_with(expected_args, cwd=tmp_path)
+
+
+def test_output_shorter_than_max_chars_returned_verbatim(tmp_path: Path) -> None:
+    """Output shorter than max_chars is returned unchanged."""
+    output = "short output\n"
+    with patch("why.diff.run_git", return_value=output):
+        result = get_commit_diff(
+            sha="abc1234", file=Path("f.py"), line_range=None, repo=tmp_path, max_chars=2000
+        )
+    assert result == output
+
+
+def test_output_truncated_when_over_max_chars(tmp_path: Path) -> None:
+    """Output of max_chars+1 chars is truncated to max_chars with a truncation suffix."""
+    max_chars = 50
+    # Build a string that is exactly max_chars+1 characters long
+    output = "x" * (max_chars + 1)
+    with patch("why.diff.run_git", return_value=output):
+        result = get_commit_diff(
+            sha="abc1234", file=Path("f.py"), line_range=None, repo=tmp_path, max_chars=max_chars
+        )
+    assert result == "x" * max_chars + "\n... [truncated]"
+
+
+def test_root_commit_fallback_on_git_error(tmp_path: Path) -> None:
+    """When git log -L raises GitError (root commit), falls back to git show whole-file."""
+    sha = "abc1234"
+    file = Path("path/to/file.py")
+    fallback_output = "fallback diff output\n"
+
+    # First call (line-range) raises GitError; second call (whole-file) succeeds.
+    with patch(
+        "why.diff.run_git",
+        side_effect=[GitError("fatal: ambiguous argument"), fallback_output],
+    ) as mock_run_git:
+        result = get_commit_diff(
+            sha=sha, file=file, line_range=(1, 2), repo=tmp_path
+        )
+
+    # Should have made exactly two calls
+    assert mock_run_git.call_count == 2
+    # Second call must be the whole-file fallback
+    second_call_args = mock_run_git.call_args_list[1]
+    assert second_call_args == call(
+        ["show", "--format=", sha, "--", str(file)], cwd=tmp_path
+    )
+    assert result == fallback_output
+
+
+def test_git_error_subclass_propagates_from_line_range_mode(tmp_path: Path) -> None:
+    """GitError subclasses (e.g. GitTimeoutError) on the -L path must not be swallowed."""
+    with patch("why.diff.run_git", side_effect=GitTimeoutError("timed out")):
+        with pytest.raises(GitTimeoutError):
+            get_commit_diff("abc1234", Path("f.py"), line_range=(1, 5), repo=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — real git repo
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def diff_repo(tmp_path: Path) -> tuple[Path, str, str]:
+    """Return (repo_path, root_sha, second_sha) for a repo with two commits.
+
+    Commit 1 (root): hello.py with 5 lines.
+    Commit 2: lines 2-3 of hello.py modified.
+    """
+    if not _tmp_path_is_clean(tmp_path):
+        pytest.skip("tmp_path is inside an existing git repo; isolation required")
+
+    git = make_git_runner(tmp_path)
+
+    git("init", "-q")
+
+    # Root commit: write hello.py with 5 lines
+    hello = tmp_path / "hello.py"
+    hello.write_text(
+        "line1\n"
+        "line2\n"
+        "line3\n"
+        "line4\n"
+        "line5\n"
+    )
+    git("add", "hello.py")
+    git("commit", "-m", "initial commit", "--quiet", date="2024-01-01T00:00:00")
+
+    # Capture root SHA
+    root_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp_path, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    # Second commit: modify lines 2-3
+    hello.write_text(
+        "line1\n"
+        "modified line2\n"
+        "modified line3\n"
+        "line4\n"
+        "line5\n"
+    )
+    git("add", "hello.py")
+    git("commit", "-m", "modify lines 2-3", "--quiet", date="2024-01-02T00:00:00")
+
+    second_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp_path, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    return tmp_path, root_sha, second_sha
+
+
+def test_integration_whole_file_diff_contains_plus_lines(
+    diff_repo: tuple[Path, str, str],
+) -> None:
+    """Whole-file diff on the second commit contains lines beginning with '+'."""
+    repo, _root_sha, second_sha = diff_repo
+    result = get_commit_diff(
+        sha=second_sha, file=Path("hello.py"), line_range=None, repo=repo
+    )
+    assert "+" in result
+
+
+def test_integration_line_range_diff_returns_nonempty(
+    diff_repo: tuple[Path, str, str],
+) -> None:
+    """Line-range diff on the second commit for lines 2-3 returns a non-empty string."""
+    repo, _root_sha, second_sha = diff_repo
+    result = get_commit_diff(
+        sha=second_sha, file=Path("hello.py"), line_range=(2, 3), repo=repo
+    )
+    assert len(result) > 0
+
+
+def test_integration_root_commit_fallback_does_not_raise(
+    diff_repo: tuple[Path, str, str],
+) -> None:
+    """Calling with line_range on the root commit triggers fallback and returns non-empty output."""
+    repo, root_sha, _second_sha = diff_repo
+    # Root commits have no parent; git log -L <sha>^! will fail — expect fallback
+    result = get_commit_diff(
+        sha=root_sha, file=Path("hello.py"), line_range=(1, 2), repo=repo
+    )
+    assert len(result) > 0


### PR DESCRIPTION
## Related Links
- Closes #11
- Design doc: `docs/designs/2026-04-24-diff-extraction-design.md`

## What
New module `src/why/diff.py` with a single public function:

```python
get_commit_diff(sha, file, line_range, repo, max_chars=2000) -> str
```

## Why
The LLM pipeline needs the concrete text of what changed in a commit, not just the message. Scoped diffs (file + line range) keep context windows focused on the relevant change.

## How
- **Whole-file** (`line_range=None`): `git show --format= <sha> -- <file>` — pure unified diff, no commit header noise
- **Line-range** (`line_range=(start, end)`): `git log -L start,end:file sha^!` — semantic line tracking, not manual hunk slicing
- **Root-commit fallback**: `git log -L` fails for root commits (no parent); catches only base `GitError` (non-zero exit) and retries as whole-file — `GitTimeoutError`, `GitNotFoundError` etc. propagate unchanged
- **Truncation**: output > `max_chars` chars is sliced and suffixed with `\n... [truncated]`

## Test Steps
- [x] `uv run pytest tests/test_diff.py -v` → 9 passed
- [x] `uv run pytest --ignore=tests/test_symbols.py -q` → 85 passed (pre-existing `test_symbols` failure unrelated)

## Other Notes
- `test_symbols.py` has a pre-existing `ModuleNotFoundError: No module named 'tree_sitter_go'` unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)