### PR TITLE
feat: why prompt template (#13)

### DIFF
--- a/docs/designs/2026-04-25-prompt-template-design.md
+++ b/docs/designs/2026-04-25-prompt-template-design.md
@@ -1,0 +1,141 @@
+# Why Prompt Template — Design Doc
+
+**Date:** 2026-04-25  
+**Issue:** #13  
+**Status:** Draft
+
+---
+
+## Problem
+
+The `why` CLI needs a prompt layer to turn raw git + diff data into a structured LLM call. Without it, the M1 synthesis pipeline has no input contract: no system prompt, no user message shape, and no citation enforcement.
+
+---
+
+## Goals
+
+- Define `WHY_SYSTEM_PROMPT` (from issue #13 comment — verbatim)
+- Define `CommitWithPR` — joins a `Commit` with its optional PR body
+- Implement `build_why_prompt(target, current_code, key_commits)` → `list[Message]`
+- Golden-file test covering a fixed, deterministic input
+
+## Non-Goals
+
+- PR fetching (GitHub API) — that's a future milestone
+- Streaming output or multi-turn conversation
+- Prompt versioning / A/B testing
+
+---
+
+## Design
+
+### `CommitWithPR`
+
+A thin frozen dataclass that joins a `Commit` with its resolved PR body. Lives in `prompts.py` because it's prompt-layer data, not core commit data.
+
+```python
+@dataclass(frozen=True)
+class CommitWithPR:
+    commit: Commit
+    pr_body: str | None = None
+```
+
+Callers (the future CLI layer) call `select_key_commits()`, then resolve PR bodies from the GitHub API (or pass `None`), and produce `list[CommitWithPR]` before calling `build_why_prompt`.
+
+---
+
+### `WHY_SYSTEM_PROMPT`
+
+Stored verbatim from the comment on issue #13. It instructs the model to:
+- Act as a "code archaeology assistant"
+- Ground every claim in a commit hash or PR ID
+- Tag every reason `[STATED]` or `[INFERRED]`
+- Follow an exact output format (Code Region → Key Evolutions → Why → Gaps → Confidence → Citations)
+- Return a fixed failure string when history is insufficient
+
+---
+
+### `build_why_prompt` — Serialization Format
+
+Returns `list[Message]` with a single `Message(role="user", ...)`. The content is **Markdown** — consistent with the system prompt's output format and readable by the LLM as natural prose structure.
+
+```
+## Target
+
+File: `src/why/scoring.py`, Line: 42
+
+---
+
+## Current Code
+
+```python
+<current_code snippet>
+```
+
+---
+
+## Commits
+
+### `abc1234` — "fix: null check on token" · 2026-04-01 · Jane Smith
+
+**Diff:**
+
+```diff
+<diff>
+```
+
+**PR Body:**
+
+<pr body or "N/A">
+
+---
+```
+
+Each commit section is a level-3 Markdown header (`###`) with the short SHA, subject, date, and author on a single line. Diff and PR body are fenced code blocks / prose under that header. Sections are separated by `---` horizontal rules to create clear parse boundaries.
+
+**Why Markdown over XML tags:**
+- The system prompt already uses Markdown headings for its OUTPUT FORMAT — feeding Markdown in is consistent
+- Diffs contain `+`/`-` prefixes that would need escaping inside XML attributes but are natural in fenced blocks
+- Markdown is more readable in tests and golden files
+
+---
+
+### Golden-file test
+
+Stored at `tests/fixtures/prompts/why_prompt_golden.txt`. Contains the expected `content` string of the single returned `Message`.
+
+Test pattern:
+```python
+def test_build_why_prompt_golden(update_goldens):
+    result = build_why_prompt(target, current_code, key_commits)
+    assert len(result) == 1
+    assert result[0].role == "user"
+    golden_path = Path("tests/fixtures/prompts/why_prompt_golden.txt")
+    if update_goldens:
+        golden_path.write_text(result[0].content)
+    else:
+        assert result[0].content == golden_path.read_text()
+```
+
+`--update-goldens` is a `conftest.py` fixture flag (addoption + fixture). No pytest plugin needed.
+
+---
+
+## File changes
+
+| File | Change |
+|------|--------|
+| `src/why/prompts.py` | New — `WHY_SYSTEM_PROMPT`, `CommitWithPR`, `build_why_prompt` |
+| `tests/test_prompts.py` | New — unit tests + golden-file test |
+| `tests/fixtures/prompts/why_prompt_golden.txt` | New — golden output |
+| `tests/conftest.py` | Add `--update-goldens` addoption + fixture |
+
+---
+
+## Acceptance criteria (from issue)
+
+- [ ] `WHY_SYSTEM_PROMPT` defined in `src/why/prompts.py`
+- [ ] `build_why_prompt(target, current_code, key_commits_with_prs)` returns `list[Message]`
+- [ ] Prompt includes: target, current code snippet, per-commit (SHA, date, author, message, diff), PR bodies if present
+- [ ] Prompt enforces citation format and `stated vs inferred` labeling (via system prompt)
+- [ ] Golden-file test on prompt output for a fixed input

--- a/src/why/prompts.py
+++ b/src/why/prompts.py
@@ -1,0 +1,262 @@
+"""Prompt-building layer for the why LLM synthesis call."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from why.commit import Commit
+from why.llm import Message
+from why.target import Target
+
+# ---------------------------------------------------------------------------
+# System prompt (verbatim — do not modify formatting)
+# ---------------------------------------------------------------------------
+
+WHY_SYSTEM_PROMPT: str = """You are a code archaeology assistant.
+
+Your job is to explain WHY a piece of code exists in its current form,
+using ONLY its Git commit history and Pull Request (PR) history.
+
+You are answering a developer who is currently reading this code and wondering:
+"why is it written like this?"
+
+---
+
+## OUTPUT REQUIREMENT (HIGHEST PRIORITY)
+
+You MUST follow the OUTPUT FORMAT exactly.
+- Do NOT add extra sections
+- Do NOT rename sections
+- Do NOT reorder sections
+- Do NOT add prose outside defined sections
+- If a section cannot be completed, include the section header and write:
+  "No evidence found in history." OR "Unclear from available history."
+
+If you deviate from this format, your response is invalid.
+
+---
+
+## INPUTS
+You will be given:
+- Code snippet (function, file, or line range)
+- Relevant commits (hash, message, diff)
+- Related PRs (title, description, discussion)
+
+---
+
+## HARD CONSTRAINTS (MUST FOLLOW)
+
+1. EVIDENCE-ONLY
+- Every claim MUST reference a commit hash or PR ID.
+- If no supporting evidence exists, write exactly:
+  "No evidence found in history."
+
+2. STATED vs INFERRED (MANDATORY TAGGING)
+- Every reason MUST be labeled:
+  - [STATED] → explicitly written in commit/PR
+  - [INFERRED] → deduced from diff patterns
+- If a statement has no tag → DO NOT include it.
+
+3. NO HALLUCINATION GUARANTEE
+- Do NOT invent intent, context, or discussions.
+- Do NOT generalize beyond the diff.
+- If unsure, explicitly say:
+  "Unclear from available history."
+
+4. STRICT CHRONOLOGY
+- Order all changes from oldest → newest.
+- Do NOT attribute intent backwards in time.
+
+5. SCOPE LOCK
+- Only explain the provided code region.
+- Ignore unrelated file changes.
+
+---
+
+## OUTPUT FORMAT (EXACT — DO NOT DEVIATE)
+
+### 📍 Code Region
+<function / file / lines>
+
+---
+
+### 🧬 Key Evolutions
+- Commit: <hash> | PR: <id or N/A> | Date: <if available>
+  - Change: ...
+  - Reason:
+    - [STATED] ...
+    - [INFERRED] ...
+
+(repeat per major change, chronological order)
+
+---
+
+### 🤔 Why This Code Looks Like This Today
+- <reason> (Commit: <hash>)
+- <reason> (PR: <id>)
+
+---
+
+### ⚠️ Gaps / Uncertainty
+- ...
+
+---
+
+### 🔍 Confidence
+
+Confidence: <High | Medium | Low>
+
+Decision Rules (apply strictly):
+- High → ≥2 commits AND ≥1 PR with explicit reasoning
+- Medium → ≥1 explicit signal + some inferred reasoning
+- Low → no explicit reasoning OR mostly inferred
+
+Justification:
+- <1–2 lines>
+
+Primary Limitation:
+- <single biggest issue affecting confidence>
+
+---
+
+### 📚 Citations
+- <commit_hash> - <message>
+- <PR_ID> - <title>
+
+---
+
+## FAILURE MODE
+
+If inputs are insufficient to produce a meaningful answer:
+Return ONLY:
+
+"Insufficient history to determine why this code exists in its current form.\""""
+
+
+# ---------------------------------------------------------------------------
+# CommitWithPR — pairs a Commit with an optional PR body and patch text
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CommitWithPR:
+    """A commit paired with its associated PR description and diff patch."""
+
+    commit: Commit
+    pr_body: str | None = None
+    diff: str = ""  # patch text from get_commit_diff(); empty = not yet fetched
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _render_target(target: Target) -> str:
+    """Return the ## Target section as a string.
+
+    Examples:
+      File: `src/foo.py`
+      File: `src/foo.py`, Line: 42
+      File: `src/foo.py`, Line: 42, Symbol: `bar`
+      File: `src/foo.py`, Symbol: `bar`
+    """
+    # Sanitize file path newlines to prevent section injection
+    safe_file = str(target.file).replace("\n", " ").replace("\r", "")
+    line = f"File: `{safe_file}`"
+
+    if target.line is not None:
+        line += f", Line: {target.line}"
+
+    if target.symbol is not None:
+        # Sanitize symbol to prevent injection
+        safe_symbol = str(target.symbol).replace("\n", " ").replace("\r", "")
+        line += f", Symbol: `{safe_symbol}`"
+
+    return f"## Target\n\n{line}"
+
+
+def _render_commit(cwpr: CommitWithPR) -> str:
+    """Render a single CommitWithPR as a Markdown commit section.
+
+    Format:
+      ### `<short_sha>` — "<subject>" · <YYYY-MM-DD> · <author_name>
+
+      **Diff:**
+
+      ```diff
+      <diff or "(no diff available)">
+      ```
+
+      **PR Body:**
+
+      <fenced pr_body or "N/A">
+
+      ---
+    """
+    commit = cwpr.commit
+
+    date_str = commit.date.strftime("%Y-%m-%d")
+
+    # Strip newlines from subject and author to prevent injecting new Markdown sections
+    safe_subject = commit.subject.replace("\n", " ").replace("\r", "")
+    # author_email intentionally omitted — PII not needed for archaeology context
+    safe_author = commit.author_name.replace("\n", " ").replace("\r", "")
+
+    # Use the explicit diff field; fall back to placeholder when not yet fetched
+    diff_text = cwpr.diff if cwpr.diff else "(no diff available)"
+
+    # Escape triple backticks in diff content to prevent premature fence closure
+    safe_diff = diff_text.replace("```", "\\`\\`\\`")
+
+    # Wrap pr_body in a ```text fence to prevent raw Markdown injection from PR descriptions.
+    # Both None and "" fall through to "N/A".
+    pr_section = f"```text\n{cwpr.pr_body}\n```" if cwpr.pr_body else "N/A"
+
+    return (
+        f'### `{commit.short_sha}` — "{safe_subject}" · {date_str} · {safe_author}\n'
+        f"\n"
+        f"**Diff:**\n"
+        f"\n"
+        f"```diff\n"
+        f"{safe_diff}\n"
+        f"```\n"
+        f"\n"
+        f"**PR Body:**\n"
+        f"\n"
+        f"{pr_section}\n"
+        f"\n"
+        f"---"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_why_prompt(
+    target: Target,
+    current_code: str,
+    key_commits: list[CommitWithPR],
+) -> list[Message]:
+    """Build the user message payload for the why LLM synthesis call.
+
+    Returns a single-element list containing a Message(role='user') whose
+    content is a Markdown document with three sections: Target (the code
+    region under analysis), Current Code (the current snapshot), and Commits
+    (each key commit with diff and PR body, oldest to newest).
+    """
+    target_section = _render_target(target)
+
+    code_section = f"## Current Code\n\n```python\n{current_code}\n```"
+
+    # Build commit sub-sections unconditionally; join is empty string when no commits
+    commits_body = "\n\n".join(_render_commit(cwpr) for cwpr in key_commits)
+    commits_section = f"## Commits\n\n{commits_body}" if commits_body else "## Commits"
+
+    # Join all sections with horizontal-rule separators
+    content = "\n\n---\n\n".join([target_section, code_section, commits_section])
+
+    return [Message(role="user", content=content)]

--- a/src/why/prompts.py
+++ b/src/why/prompts.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from pathlib import Path
+from dataclasses import dataclass
 
 from why.commit import Commit
 from why.llm import Message
@@ -113,7 +112,7 @@ Decision Rules (apply strictly):
 - Low → no explicit reasoning OR mostly inferred
 
 Justification:
-- <1–2 lines>
+- <1-2 lines>
 
 Primary Limitation:
 - <single biggest issue affecting confidence>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,19 @@ import subprocess
 from collections.abc import Callable
 from pathlib import Path
 
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the --update-goldens flag for regenerating golden files."""
+    parser.addoption("--update-goldens", action="store_true", default=False)
+
+
+@pytest.fixture
+def update_goldens(request: pytest.FixtureRequest) -> bool:
+    """Return True when --update-goldens was passed on the command line."""
+    return bool(request.config.getoption("--update-goldens"))
+
 
 def _tmp_path_is_clean(tmp_path: Path) -> bool:
     """Return True if tmp_path is NOT inside an existing git repo.

--- a/tests/fixtures/prompts/why_prompt_golden.txt
+++ b/tests/fixtures/prompts/why_prompt_golden.txt
@@ -1,0 +1,32 @@
+## Target
+
+File: `src/why/scoring.py`, Line: 42
+
+---
+
+## Current Code
+
+```python
+def score_commit(c: Commit, now: date, has_pr: bool) -> float:
+    return 0.0
+```
+
+---
+
+## Commits
+
+### `abc1234` — "fix: handle null token in auth check" · 2026-01-15 · Jane Smith
+
+**Diff:**
+
+```diff
+(no diff available)
+```
+
+**PR Body:**
+
+```text
+Fixes #99: adds null check
+```
+
+---

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,285 @@
+"""Tests for why.prompts — written BEFORE the implementation (TDD).
+
+Fixed, deterministic test data; no datetime.now() calls.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from why.commit import Commit
+from why.llm import Message
+from why.prompts import CommitWithPR, WHY_SYSTEM_PROMPT, build_why_prompt
+from why.target import Target
+
+# ---------------------------------------------------------------------------
+# Deterministic test fixtures
+# ---------------------------------------------------------------------------
+
+FIXED_DATE = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+FIXED_COMMIT = Commit(
+    sha="abc1234def5678901234567890",
+    author_name="Jane Smith",
+    author_email="jane@example.com",
+    date=FIXED_DATE,
+    subject="fix: handle null token in auth check",
+    body="- removed None guard\n+ added explicit null check",
+    parents=("aaabbbccc",),
+    additions=3,
+    deletions=1,
+)
+FIXED_TARGET = Target(file=Path("src/why/scoring.py"), line=42)
+FIXED_CURRENT_CODE = (
+    "def score_commit(c: Commit, now: date, has_pr: bool) -> float:\n    return 0.0"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a prompt with the fixed commit and target
+# ---------------------------------------------------------------------------
+
+
+def _default_result() -> list[Message]:
+    """Return build_why_prompt with the FIXED_COMMIT (no PR body)."""
+    commits = [CommitWithPR(commit=FIXED_COMMIT)]
+    return build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: result structure — single user Message
+# ---------------------------------------------------------------------------
+
+
+def test_returns_single_user_message() -> None:
+    """build_why_prompt must return a list with exactly one Message(role='user')."""
+    result = _default_result()
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], Message)
+    assert result[0].role == "user"
+
+
+# ---------------------------------------------------------------------------
+# Test 2–4: target rendering variants
+# ---------------------------------------------------------------------------
+
+
+def test_target_file_only() -> None:
+    """A target with no line or symbol must render just the file path."""
+    target = Target(file=Path("src/why/scoring.py"))
+    result = build_why_prompt(target, FIXED_CURRENT_CODE, [])
+    content = result[0].content
+    # Should show the file but NOT 'Line:' or 'Symbol:'
+    assert "File: `src/why/scoring.py`" in content
+    assert "Line:" not in content
+    assert "Symbol:" not in content
+
+
+def test_target_with_line() -> None:
+    """A target with line=42 must render 'File: ..., Line: 42'."""
+    target = Target(file=Path("src/why/scoring.py"), line=42)
+    result = build_why_prompt(target, FIXED_CURRENT_CODE, [])
+    content = result[0].content
+    assert "File: `src/why/scoring.py`, Line: 42" in content
+
+
+def test_target_with_symbol() -> None:
+    """A target with symbol must append ', Symbol: `<symbol>`'."""
+    target = Target(file=Path("src/why/scoring.py"), symbol="score_commit")
+    result = build_why_prompt(target, FIXED_CURRENT_CODE, [])
+    content = result[0].content
+    assert "Symbol: `score_commit`" in content
+
+
+# ---------------------------------------------------------------------------
+# Test 5–6: commit rendering — SHA and date
+# ---------------------------------------------------------------------------
+
+
+def test_commit_sha_is_short() -> None:
+    """Commit section header must use the 7-char short SHA (abc1234)."""
+    content = _default_result()[0].content
+    assert "abc1234" in content
+    # Full SHA must NOT appear as the header SHA
+    assert "abc1234def5678901234567890" not in content.split("###")[1]
+
+
+def test_commit_date_format() -> None:
+    """Commit date must appear as YYYY-MM-DD only (no time component)."""
+    content = _default_result()[0].content
+    assert "2026-01-15" in content
+    # The full ISO timestamp must not appear in the commit header line
+    assert "12:00:00" not in content
+
+
+# ---------------------------------------------------------------------------
+# Test 7–8: PR body presence / absence
+# ---------------------------------------------------------------------------
+
+
+def test_pr_body_present() -> None:
+    """When pr_body is set, the content string must appear verbatim."""
+    commits = [CommitWithPR(commit=FIXED_COMMIT, pr_body="Fixes #99: adds null check")]
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
+    assert "Fixes #99: adds null check" in result[0].content
+
+
+def test_pr_body_absent() -> None:
+    """When pr_body is None, the PR Body section must show 'N/A'."""
+    commits = [CommitWithPR(commit=FIXED_COMMIT, pr_body=None)]
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
+    assert "N/A" in result[0].content
+
+
+# ---------------------------------------------------------------------------
+# Test 9: empty commit list
+# ---------------------------------------------------------------------------
+
+
+def test_no_commits() -> None:
+    """An empty key_commits list must return a valid single user Message."""
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [])
+    assert len(result) == 1
+    assert result[0].role == "user"
+    # Target section must still be present
+    assert "## Target" in result[0].content
+    assert "## Current Code" in result[0].content
+    # Commits section must be present with just the header — no trailing empty body
+    assert "## Commits" in result[0].content
+    assert "## Commits\n\n" not in result[0].content
+
+
+# ---------------------------------------------------------------------------
+# Test 10: WHY_SYSTEM_PROMPT is a non-empty string
+# ---------------------------------------------------------------------------
+
+
+def test_system_prompt_not_empty() -> None:
+    """WHY_SYSTEM_PROMPT must be a non-empty string."""
+    assert isinstance(WHY_SYSTEM_PROMPT, str)
+    assert len(WHY_SYSTEM_PROMPT) > 0
+
+
+# ---------------------------------------------------------------------------
+# Test 11: golden file comparison
+# ---------------------------------------------------------------------------
+
+
+def test_golden_file(update_goldens: bool) -> None:
+    """Content must match the golden fixture exactly."""
+    commits = [CommitWithPR(commit=FIXED_COMMIT, pr_body="Fixes #99: adds null check")]
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
+    content = result[0].content
+    golden = Path(__file__).parent / "fixtures" / "prompts" / "why_prompt_golden.txt"
+    if update_goldens:
+        golden.parent.mkdir(parents=True, exist_ok=True)
+        golden.write_text(content)
+        return
+    assert golden.exists(), "Golden file missing — run with --update-goldens to create"
+    assert content == golden.read_text()
+
+
+# ---------------------------------------------------------------------------
+# B1: diff field on CommitWithPR
+# ---------------------------------------------------------------------------
+
+
+def test_diff_field_used_in_render() -> None:
+    """CommitWithPR.diff is rendered in the diff fence, not commit.body."""
+    cwpr = CommitWithPR(
+        commit=FIXED_COMMIT,
+        diff="+ new line added\n- old line removed",
+    )
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [cwpr])
+    content = result[0].content
+    # The explicit diff field should appear
+    assert "+ new line added" in content
+    assert "- old line removed" in content
+    # commit.body should NOT be used as the diff
+    assert "removed None guard" not in content
+
+
+def test_diff_empty_shows_placeholder() -> None:
+    """When diff is empty (not yet fetched), the placeholder text is shown."""
+    cwpr = CommitWithPR(commit=FIXED_COMMIT, diff="")
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [cwpr])
+    assert "(no diff available)" in result[0].content
+
+
+# ---------------------------------------------------------------------------
+# B2: Prompt injection mitigations
+# ---------------------------------------------------------------------------
+
+
+def test_newline_in_subject_is_stripped() -> None:
+    """Newlines in commit.subject must be collapsed to spaces in the header."""
+    injected_commit = Commit(
+        sha="abc1234def5678901234567890",
+        author_name="Jane Smith",
+        author_email="jane@example.com",
+        date=FIXED_DATE,
+        subject="fix: legit\n## Injected Section",
+        body="",
+        parents=("aaabbbccc",),
+    )
+    cwpr = CommitWithPR(commit=injected_commit, diff="some diff")
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [cwpr])
+    content = result[0].content
+    # The injected newline must be replaced — no raw newline in the ### header line
+    header_line = [ln for ln in content.splitlines() if ln.startswith("### `abc1234`")][0]
+    assert "\n" not in header_line
+    # "## Injected Section" must NOT appear as a standalone Markdown heading line —
+    # it should be inlined into the header text after the newline was stripped to a space
+    assert "\n## Injected Section" not in content
+
+
+def test_backtick_fence_in_diff_is_escaped() -> None:
+    """Triple backticks inside the diff must be escaped to prevent fence breakout."""
+    cwpr = CommitWithPR(
+        commit=FIXED_COMMIT,
+        diff="some code\n```\nmore code",
+    )
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [cwpr])
+    content = result[0].content
+    # The raw triple-backtick must not appear unescaped inside the diff block
+    # Find the diff fence and check the content within it
+    assert "\\`\\`\\`" in content
+
+
+def test_pr_body_is_fenced() -> None:
+    """PR body must be wrapped in a ```text fence to prevent Markdown injection."""
+    cwpr = CommitWithPR(
+        commit=FIXED_COMMIT,
+        pr_body="## Injected Heading\nsome content",
+    )
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [cwpr])
+    content = result[0].content
+    assert "```text" in content
+    assert "## Injected Heading" in content  # content preserved but fenced
+
+
+# ---------------------------------------------------------------------------
+# N2: pr_body="" should render as "N/A"
+# ---------------------------------------------------------------------------
+
+
+def test_pr_body_empty_string() -> None:
+    """An empty string pr_body must render as 'N/A', same as None."""
+    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_body="")
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [cwpr])
+    assert "N/A" in result[0].content
+
+
+# ---------------------------------------------------------------------------
+# N3: target with both line and symbol
+# ---------------------------------------------------------------------------
+
+
+def test_target_with_line_and_symbol() -> None:
+    """A target with both line and symbol must render both in the header."""
+    target = Target(file=Path("src/why/scoring.py"), line=42, symbol="score_commit")
+    result = build_why_prompt(target, FIXED_CURRENT_CODE, [])
+    assert "File: `src/why/scoring.py`, Line: 42, Symbol: `score_commit`" in result[0].content

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -5,21 +5,19 @@ Fixed, deterministic test data; no datetime.now() calls.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-
-import pytest
 
 from why.commit import Commit
 from why.llm import Message
-from why.prompts import CommitWithPR, WHY_SYSTEM_PROMPT, build_why_prompt
+from why.prompts import WHY_SYSTEM_PROMPT, CommitWithPR, build_why_prompt
 from why.target import Target
 
 # ---------------------------------------------------------------------------
 # Deterministic test fixtures
 # ---------------------------------------------------------------------------
 
-FIXED_DATE = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+FIXED_DATE = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
 FIXED_COMMIT = Commit(
     sha="abc1234def5678901234567890",
     author_name="Jane Smith",
@@ -63,7 +61,7 @@ def test_returns_single_user_message() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test 2–4: target rendering variants
+# Test 2-4: target rendering variants
 # ---------------------------------------------------------------------------
 
 
@@ -95,7 +93,7 @@ def test_target_with_symbol() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test 5–6: commit rendering — SHA and date
+# Test 5-6: commit rendering - SHA and date
 # ---------------------------------------------------------------------------
 
 
@@ -116,7 +114,7 @@ def test_commit_date_format() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test 7–8: PR body presence / absence
+# Test 7-8: PR body presence / absence
 # ---------------------------------------------------------------------------
 
 
@@ -229,7 +227,7 @@ def test_newline_in_subject_is_stripped() -> None:
     result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [cwpr])
     content = result[0].content
     # The injected newline must be replaced — no raw newline in the ### header line
-    header_line = [ln for ln in content.splitlines() if ln.startswith("### `abc1234`")][0]
+    header_line = next(ln for ln in content.splitlines() if ln.startswith("### `abc1234`"))
     assert "\n" not in header_line
     # "## Injected Section" must NOT appear as a standalone Markdown heading line —
     # it should be inlined into the header text after the newline was stripped to a space


### PR DESCRIPTION
## Related Links

- Closes #13
- Depends on #12 (LLM provider abstraction — merged)

## What

Adds the prompt-building layer for the `why` LLM synthesis call:

- `WHY_SYSTEM_PROMPT` — verbatim code-archaeology system prompt with hard constraints (evidence-only, `[STATED]`/`[INFERRED]` tagging, no hallucination, strict chronology, exact output format)
- `CommitWithPR` — frozen dataclass pairing a `Commit` with its optional PR body and diff patch
- `build_why_prompt(target, current_code, key_commits)` — serializes target + current code + key commits into a structured Markdown user `Message`

## Why

Closes the last gap before the M1 synthesis pipeline can make its first real LLM call. Without a prompt layer there's no input contract: no citation enforcement, no output format guarantee, no anti-hallucination rules.

## How

**Serialization format:** Markdown — three sections (`## Target`, `## Current Code`, `## Commits`) joined by `---` horizontal rules. Each commit renders as a `###` header with fenced diff and PR body blocks.

**Injection hardening:**
- Newlines stripped from `commit.subject` and `author_name` (prevents heading injection)
- Triple backticks escaped in diff content (prevents fence breakout)
- `pr_body` wrapped in a ` ```text ``` ` fence (contains raw Markdown from PR descriptions)

**`CommitWithPR.diff`** is an explicit field (not `commit.body`) — callers populate it via `get_commit_diff()`.

## Test Steps

- [ ] `uv run python -m pytest tests/ -x` → 133 passed
- [ ] `uv run python -m mypy src/why/prompts.py --strict` → no issues
- [ ] Golden file at `tests/fixtures/prompts/why_prompt_golden.txt` reflects current rendering; regenerate with `--update-goldens` if prompt shape changes

## Other Notes

Design doc: `docs/designs/2026-04-25-prompt-template-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)