### PR TITLE
test(cli): e2e integration test for why <file>:<line> target form

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def _tmp_path_is_clean(tmp_path: Path) -> bool:
     """
     result = subprocess.run(
         ["git", "rev-parse", "--git-dir"],
-        cwd=tmp_path, capture_output=True, text=True, check=False,
+        cwd=tmp_path.resolve(), capture_output=True, text=True, check=False,
     )
     return result.returncode != 0
 
@@ -50,6 +50,10 @@ def make_git_runner(repo: Path) -> Callable[..., None]:
         "GIT_COMMITTER_NAME": "Test",
         "GIT_COMMITTER_EMAIL": "test@example.com",
         "GIT_TERMINAL_PROMPT": "0",
+        # Prevent git from reading /etc/gitconfig or ~/.gitconfig so host
+        # settings (e.g. gpgsign=true, custom hooks) can't affect test runs.
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "HOME": str(repo),
         # Match run_git's _HARDENING_ENV so fixture output is locale-stable
         # and never blocked by a pager.
         "LC_ALL": "C",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -239,4 +239,6 @@ class TestLineTargetEndToEnd:
         # catching regressions where the pipeline passes an empty or wrong prompt.
         call_args = mock_llm_instance.complete.call_args
         messages = call_args.args[1]
-        assert any("foo.py" in str(m) for m in messages), "LLM messages should reference the target file"
+        assert any("foo.py" in str(m) for m in messages), (
+            "LLM messages should reference the target file"
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,3 +125,118 @@ def test_no_args_shows_help() -> None:
     # Click's no_args_is_help always exits 2 (UsageError), not 0
     assert result.exit_code == 2
     assert "TARGET" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Real-git integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def line_history_cli_repo(tmp_path: Path) -> Path:
+    """Build a real git repo where 3 commits each touch line 1 of foo.py.
+
+    This mirrors the `line_history_repo` fixture in test_history.py but lives
+    here so CLI end-to-end tests have a self-contained isolated repo.
+
+    History (oldest to newest):
+      A — write 10 lines to foo.py (line 1 = "line1")
+      B — change line 1 to "line1 updated"
+      C — change line 1 to "line1 final"
+
+    Returns the repo root Path.
+    """
+    from conftest import _tmp_path_is_clean, make_git_runner
+
+    if not _tmp_path_is_clean(tmp_path):
+        pytest.skip("tmp_path is inside an existing git repo — skipping integration test")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    git = make_git_runner(repo)
+    import subprocess as _sp
+    _git_ver = _sp.run(["git", "--version"], capture_output=True, text=True, check=True).stdout
+    # "git version 2.39.2" → (2, 39)
+    _major, _minor = (int(x) for x in _git_ver.split()[2].split(".")[:2])
+    if (_major, _minor) >= (2, 28):
+        git("init", "-b", "main")
+    else:
+        git("init")
+        git("symbolic-ref", "HEAD", "refs/heads/main")
+
+    # Commit A: create foo.py with 10 lines
+    lines = "\n".join(f"line{i}" for i in range(1, 11)) + "\n"
+    (repo / "foo.py").write_text(lines)
+    git("add", "foo.py")
+    git("commit", "-m", "A: create foo.py")
+
+    # Commit B: update line 1
+    lines_b = "\n".join(
+        ["line1 updated"] + [f"line{i}" for i in range(2, 11)]
+    ) + "\n"
+    (repo / "foo.py").write_text(lines_b)
+    git("add", "foo.py")
+    git("commit", "-m", "B: update line 1")
+
+    # Commit C: update line 1 again
+    lines_c = "\n".join(
+        ["line1 final"] + [f"line{i}" for i in range(2, 11)]
+    ) + "\n"
+    (repo / "foo.py").write_text(lines_c)
+    git("add", "foo.py")
+    git("commit", "-m", "C: finalize line 1")
+
+    return repo
+
+
+class TestLineTargetEndToEnd:
+    """CLI end-to-end: `why <file>:1` runs the full stack against a real git repo."""
+
+    def test_file_line_target_runs_end_to_end(
+        self, line_history_cli_repo: Path
+    ) -> None:
+        """Invoking `why foo.py:1` on a real git repo:
+
+        - Passes through parse_target, get_line_history, and synthesize_why
+          for real (none of those are mocked).
+        - LLMClient.complete() is mocked to return "line explanation" so the
+          test is hermetic without a live API key.
+        - Path.cwd() is redirected to the test repo root so parse_target can
+          resolve the absolute path without raising "path escapes repository root".
+        - Exit code must be 0, output must contain the mocked explanation, and
+          LLMClient must be constructed exactly once.
+        """
+        repo = line_history_cli_repo
+        # Resolve symlinks so parse_target's relative_to guard passes on macOS
+        # (tmp_path may be /var/folders/… which resolves to /private/var/folders/…).
+        target_spec = str((repo / "foo.py").resolve()) + ":1"
+
+        with (
+            patch("why.cli.Path") as mock_path_cls,
+            patch("why.cli.LLMClient") as mock_llm_cls,
+        ):
+            # Forward all Path construction to the real Path so synthesize_why
+            # and parse_target keep working — only override cwd() to point at
+            # the test repo so the "path escapes repo root" guard passes.
+            mock_path_cls.side_effect = Path
+            mock_path_cls.cwd.return_value = repo.resolve()
+
+            # Wire the mock instance so .complete() returns our sentinel string
+            mock_llm_instance = MagicMock()
+            mock_llm_instance.complete.return_value = "line explanation"
+            mock_llm_cls.return_value = mock_llm_instance
+
+            result = CliRunner().invoke(main, [target_spec])
+
+        assert result.exit_code == 0, result.output
+        assert result.output.strip() == "line explanation"
+        # LLMClient must be constructed once (with the default model)
+        mock_llm_cls.assert_called_once()
+        # complete() must be called — guards against future short-circuit paths
+        mock_llm_instance.complete.assert_called_once()
+        # Verify the LLM received a prompt that references the target file,
+        # catching regressions where the pipeline passes an empty or wrong prompt.
+        call_args = mock_llm_instance.complete.call_args
+        messages = call_args.args[1]
+        assert any("foo.py" in str(m) for m in messages), "LLM messages should reference the target file"


### PR DESCRIPTION
## Related Links
- Closes #17

## What
Adds `TestLineTargetEndToEnd.test_file_line_target_runs_end_to_end` — a real-git CLI integration test for `why foo.py:1`. The test builds a 3-commit git repo via fixture, runs the full pipeline (parse_target → get_line_history → select_key_commits → get_commit_diff → synthesize_why), and mocks only `LLMClient.complete`.

Also tightens `tests/conftest.py` fixture isolation:
- `_tmp_path_is_clean` now uses `tmp_path.resolve()` to avoid macOS symlink false-negatives
- `make_git_runner` adds `GIT_CONFIG_NOSYSTEM=1` and `HOME=str(repo)` so host gitconfig (e.g. `gpgsign=true`, custom hooks) can't affect fixture runs

## Why
Issue #17 required a test exercising the `file:line` CLI path end-to-end. All production code was already in place — only the integration test was missing. The conftest fixes eliminate a class of non-deterministic CI failures caused by developer host configuration leaking into test subprocess environments.

## How
- New `line_history_cli_repo` fixture creates a real git repo with 10-line `foo.py` and 3 commits each modifying line 1
- `mock_path_cls.side_effect = Path` + `mock_path_cls.cwd.return_value = repo.resolve()` lets parse_target use the real Path class while pointing cwd at the test repo
- `git init -b main` guarded with a version check; falls back to `git symbolic-ref HEAD refs/heads/main` for git < 2.28
- `complete.assert_called_once()` + inspection of `call_args.args[1]` (the messages list) guards against short-circuit regressions

## Test Steps
- [ ] `uv run pytest tests/test_cli.py -v` — 8 passed
- [ ] `uv run pytest -x -q` — 177 passed

## Other Notes
`_LINE_WINDOW = 20` (±20 lines around the target line) kept as-is — the issue spec mentions "10 lines" informally but more context improves LLM output quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)