### PR TITLE
feat: wire CLI entry for why <file> <symbol> target form (#18)

### DIFF
--- a/src/why/cli.py
+++ b/src/why/cli.py
@@ -8,6 +8,7 @@ import click
 from why import __version__
 from why.git import GitError
 from why.llm import LLMClient, LLMError
+from why.symbols import SymbolNotFoundError
 from why.synth import synthesize_why
 from why.target import TargetError, parse_target
 
@@ -50,7 +51,7 @@ def main(target_spec: str, extra: str | None, model: str) -> None:
     try:
         llm = LLMClient(model)
         output = synthesize_why(target, cwd, llm)
-    except (LLMError, GitError) as exc:
+    except (LLMError, GitError, SymbolNotFoundError) as exc:
         click.echo(f"Error: {exc}", err=True)
         sys.exit(1)
 

--- a/src/why/synth.py
+++ b/src/why/synth.py
@@ -12,7 +12,7 @@ from why.history import get_file_history, get_line_history
 from why.llm import LLMClient
 from why.prompts import WHY_SYSTEM_PROMPT, CommitWithPR, build_why_prompt
 from why.scoring import select_key_commits
-from why.symbols import SymbolNotFoundError, find_symbol_range
+from why.symbols import find_symbol_range
 from why.target import Target
 
 _log = logging.getLogger(__name__)
@@ -25,15 +25,18 @@ def _extract_current_code(target: Target, line_range: tuple[int, int] | None = N
     """Return the relevant source text for *target*.
 
     Priority order:
-    1. Symbol — use the pre-resolved line_range if provided; fall back to full
-       file when line_range is None (symbol not found).
+    1. Symbol — use the pre-resolved line_range (must not be None; callers
+       are responsible for resolving via _resolve_line_range first).
     2. Line — return a ±_LINE_WINDOW window around the given line, clamped
        to file bounds.
     3. File-only — return the entire file text.
     """
     if target.symbol is not None:
-        if line_range is None:
-            return target.file.read_text()
+        # line_range is always resolved before this call for symbol targets;
+        # SymbolNotFoundError is raised by _resolve_line_range if the symbol is missing.
+        assert line_range is not None, (
+            "_extract_current_code: symbol target requires a resolved line_range"
+        )
         start, end = line_range
         lines = target.file.read_text().splitlines(keepends=True)
         return "".join(lines[start - 1 : end])
@@ -53,15 +56,13 @@ def _resolve_line_range(target: Target) -> tuple[int, int] | None:
     """Return the (start, end) line range (1-based, inclusive) for *target*.
 
     Priority order:
-    1. Symbol — delegate to find_symbol_range; return None on SymbolNotFoundError.
+    1. Symbol — delegate to find_symbol_range; raises SymbolNotFoundError if missing.
     2. Line — return (line, line).
     3. File-only — return None (no narrowing possible).
     """
     if target.symbol is not None:
-        try:
-            return find_symbol_range(target.file, target.symbol)
-        except SymbolNotFoundError:
-            return None
+        # Let SymbolNotFoundError propagate so the CLI can surface it to the user.
+        return find_symbol_range(target.file, target.symbol)
 
     if target.line is not None:
         return (target.line, target.line)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,26 @@ def _tmp_path_is_clean(tmp_path: Path) -> bool:
     return result.returncode != 0
 
 
+def init_git_main_branch(git_runner: Callable[..., None]) -> None:
+    """Init a git repo on branch 'main', handling git < 2.28.
+
+    git 2.28 introduced the -b flag for `git init`; older versions require a
+    separate `symbolic-ref` call to rename the default branch to main.
+    """
+    import subprocess as _sp
+
+    ver_out = _sp.run(
+        ["git", "--version"], capture_output=True, text=True, check=True
+    ).stdout
+    # "git version 2.39.2" → (2, 39)
+    major, minor = (int(x) for x in ver_out.split()[2].split(".")[:2])
+    if (major, minor) >= (2, 28):
+        git_runner("init", "-b", "main")
+    else:
+        git_runner("init")
+        git_runner("symbolic-ref", "HEAD", "refs/heads/main")
+
+
 def make_git_runner(repo: Path) -> Callable[..., None]:
     """Return a git() callable pre-configured for repo with test env vars.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,7 +146,7 @@ def line_history_cli_repo(tmp_path: Path) -> Path:
 
     Returns the repo root Path.
     """
-    from conftest import _tmp_path_is_clean, make_git_runner
+    from conftest import _tmp_path_is_clean, init_git_main_branch, make_git_runner
 
     if not _tmp_path_is_clean(tmp_path):
         pytest.skip("tmp_path is inside an existing git repo — skipping integration test")
@@ -155,15 +155,7 @@ def line_history_cli_repo(tmp_path: Path) -> Path:
     repo.mkdir()
 
     git = make_git_runner(repo)
-    import subprocess as _sp
-    _git_ver = _sp.run(["git", "--version"], capture_output=True, text=True, check=True).stdout
-    # "git version 2.39.2" → (2, 39)
-    _major, _minor = (int(x) for x in _git_ver.split()[2].split(".")[:2])
-    if (_major, _minor) >= (2, 28):
-        git("init", "-b", "main")
-    else:
-        git("init")
-        git("symbolic-ref", "HEAD", "refs/heads/main")
+    init_git_main_branch(git)
 
     # Commit A: create foo.py with 10 lines
     lines = "\n".join(f"line{i}" for i in range(1, 11)) + "\n"
@@ -242,3 +234,201 @@ class TestLineTargetEndToEnd:
         assert any("foo.py" in str(m) for m in messages), (
             "LLM messages should reference the target file"
         )
+
+
+# ---------------------------------------------------------------------------
+# Real-git integration tests — symbol target
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def symbol_history_cli_repo(tmp_path: Path) -> Path:
+    """Build a real git repo where 3 commits each modify authenticate_user in auth.py.
+
+    History (oldest to newest):
+      A — create auth.py with a basic authenticate_user function (10+ lines)
+      B — update authenticate_user to add a validation check
+      C — update authenticate_user to change return logic
+
+    Returns the repo root Path.
+    """
+    from conftest import _tmp_path_is_clean, init_git_main_branch, make_git_runner
+
+    if not _tmp_path_is_clean(tmp_path):
+        pytest.skip("tmp_path is inside an existing git repo — skipping integration test")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    git = make_git_runner(repo)
+    init_git_main_branch(git)
+
+    # Commit A: create auth.py with a basic authenticate_user function (10+ lines total)
+    auth_a = (
+        "\"\"\"Authentication module.\"\"\"\n"
+        "\n"
+        "VALID_USERS = {\"alice\": \"secret\", \"bob\": \"password\"}\n"
+        "\n"
+        "\n"
+        "def authenticate_user(username: str, password: str) -> bool:\n"
+        "    \"\"\"Return True if credentials are valid.\"\"\"\n"
+        "    stored = VALID_USERS.get(username)\n"
+        "    return stored == password\n"
+        "\n"
+        "\n"
+        "def logout_user(username: str) -> None:\n"
+        "    \"\"\"Log the user out.\"\"\"\n"
+        "    pass\n"
+    )
+    (repo / "auth.py").write_text(auth_a)
+    git("add", "auth.py")
+    git("commit", "-m", "A: create auth.py with authenticate_user")
+
+    # Commit B: add an empty-string check to authenticate_user
+    auth_b = (
+        "\"\"\"Authentication module.\"\"\"\n"
+        "\n"
+        "VALID_USERS = {\"alice\": \"secret\", \"bob\": \"password\"}\n"
+        "\n"
+        "\n"
+        "def authenticate_user(username: str, password: str) -> bool:\n"
+        "    \"\"\"Return True if credentials are valid.\"\"\"\n"
+        "    if not username or not password:\n"
+        "        return False\n"
+        "    stored = VALID_USERS.get(username)\n"
+        "    return stored == password\n"
+        "\n"
+        "\n"
+        "def logout_user(username: str) -> None:\n"
+        "    \"\"\"Log the user out.\"\"\"\n"
+        "    pass\n"
+    )
+    (repo / "auth.py").write_text(auth_b)
+    git("add", "auth.py")
+    git("commit", "-m", "B: add blank-credential guard to authenticate_user")
+
+    # Commit C: change return logic to raise on unknown user
+    auth_c = (
+        "\"\"\"Authentication module.\"\"\"\n"
+        "\n"
+        "VALID_USERS = {\"alice\": \"secret\", \"bob\": \"password\"}\n"
+        "\n"
+        "\n"
+        "def authenticate_user(username: str, password: str) -> bool:\n"
+        "    \"\"\"Return True if credentials are valid, False if wrong password.\"\"\"\n"
+        "    if not username or not password:\n"
+        "        return False\n"
+        "    stored = VALID_USERS.get(username)\n"
+        "    if stored is None:\n"
+        "        return False\n"
+        "    return stored == password\n"
+        "\n"
+        "\n"
+        "def logout_user(username: str) -> None:\n"
+        "    \"\"\"Log the user out.\"\"\"\n"
+        "    pass\n"
+    )
+    (repo / "auth.py").write_text(auth_c)
+    git("add", "auth.py")
+    git("commit", "-m", "C: return False for unknown user in authenticate_user")
+
+    return repo
+
+
+class TestSymbolTargetEndToEnd:
+    """CLI end-to-end: `why <file> <symbol>` runs the full stack against a real git repo."""
+
+    def test_file_symbol_target_runs_end_to_end(
+        self, symbol_history_cli_repo: Path
+    ) -> None:
+        """Invoking `why auth.py authenticate_user` on a real git repo:
+
+        - Passes through parse_target, find_symbol_range, get_line_history, and
+          synthesize_why for real (none of those are mocked).
+        - LLMClient.complete() is mocked to return "symbol explanation" so the
+          test is hermetic without a live API key.
+        - Path.cwd() is redirected to the test repo root so parse_target can
+          resolve the absolute path without raising "path escapes repository root".
+        - Exit code must be 0, output must equal the mocked explanation, and
+          LLMClient must be constructed and called exactly once.
+        - The LLM messages must reference both "auth.py" and "authenticate_user",
+          proving find_symbol_range was invoked and the symbol name reached the prompt.
+        """
+        from why.symbols import find_symbol_range as _real_find_symbol_range
+
+        repo = symbol_history_cli_repo
+        # Resolve symlinks so parse_target's relative_to guard passes on macOS
+        # (tmp_path may be /var/folders/… which resolves to /private/var/folders/…).
+        target_spec = str((repo / "auth.py").resolve())
+
+        with (
+            patch("why.cli.Path") as mock_path_cls,
+            patch("why.cli.LLMClient") as mock_llm_cls,
+            patch("why.synth.find_symbol_range", wraps=_real_find_symbol_range) as spy_fsr,
+        ):
+            # Forward all Path construction to the real Path so synthesize_why
+            # and parse_target keep working — only override cwd() to point at
+            # the test repo so the "path escapes repo root" guard passes.
+            mock_path_cls.side_effect = Path
+            mock_path_cls.cwd.return_value = repo.resolve()
+
+            # Wire the mock instance so .complete() returns our sentinel string
+            mock_llm_instance = MagicMock()
+            mock_llm_instance.complete.return_value = "symbol explanation"
+            mock_llm_cls.return_value = mock_llm_instance
+
+            result = CliRunner().invoke(main, [target_spec, "authenticate_user"])
+
+        assert result.exit_code == 0, result.output
+        assert result.output.strip() == "symbol explanation"
+        # LLMClient must be constructed once (with the default model)
+        mock_llm_cls.assert_called_once()
+        # complete() must be called — guards against future short-circuit paths
+        mock_llm_instance.complete.assert_called_once()
+        # Verify the LLM received a prompt that references the target file,
+        # catching regressions where the pipeline passes an empty or wrong prompt.
+        messages = mock_llm_instance.complete.call_args.args[1]
+        assert any("auth.py" in str(m) for m in messages), (
+            "LLM messages should reference the target file"
+        )
+        # Verify the symbol name appears in the prompt — proves find_symbol_range
+        # was used and the symbol was threaded through to the LLM prompt.
+        assert any("authenticate_user" in str(m) for m in messages), (
+            "LLM messages should reference the symbol name"
+        )
+        # Prove find_symbol_range was called by tree-sitter with the right arguments.
+        spy_fsr.assert_called_once_with(
+            (repo / "auth.py").resolve(), "authenticate_user"
+        )
+
+    def test_symbol_not_found_exits_1(
+        self, line_history_cli_repo: Path
+    ) -> None:
+        """Invoking `why foo.py nonexistent_func` on a real git repo exits 1.
+
+        The symbol doesn't exist in the file, so find_symbol_range raises
+        SymbolNotFoundError. The CLI must surface this as exit 1 with "Error:"
+        in output instead of silently falling back to file-scoped history.
+
+        # Uses line_history_cli_repo: any real .py file suffices; we only need
+        # the SymbolNotFoundError path.
+        """
+        repo = line_history_cli_repo
+        # Resolve symlinks so parse_target's relative_to guard passes on macOS.
+        target_file = (repo / "foo.py").resolve()
+
+        with (
+            patch("why.cli.Path") as mock_path_cls,
+            patch("why.cli.LLMClient") as mock_llm_cls,
+        ):
+            # Forward all Path construction to the real Path; only override cwd().
+            mock_path_cls.side_effect = Path
+            mock_path_cls.cwd.return_value = repo.resolve()
+
+            mock_llm_instance = MagicMock()
+            mock_llm_cls.return_value = mock_llm_instance
+
+            result = CliRunner().invoke(main, [str(target_file), "nonexistent_func"])
+
+        assert result.exit_code == 1, result.output
+        assert "Error:" in result.output

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -7,7 +7,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from why.commit import Commit
+from why.symbols import SymbolNotFoundError
 from why.synth import _extract_current_code, _resolve_line_range, synthesize_why
 from why.target import Target
 
@@ -62,15 +65,12 @@ class TestExtractCurrentCodeSymbol:
         assert "x = 1" not in result
         assert "z = 3" not in result
 
-    def test_symbol_not_found_falls_back_to_full_file(self, tmp_path: Path) -> None:
-        content = "def exists():\n    pass\n"
-        f = _make_py_file(tmp_path, "sample.py", content)
-        target = Target(file=f, symbol="nonexistent")
-
-        # Must not raise; must return full file text
-        result = _extract_current_code(target)
-
-        assert result == content
+    def test_symbol_requires_line_range(self, tmp_path: Path) -> None:
+        """Passing line_range=None for a symbol target triggers the assertion guard."""
+        f = _make_py_file(tmp_path, "s.py", "def foo():\n    pass\n")
+        target = Target(file=f, symbol="foo")
+        with pytest.raises(AssertionError):
+            _extract_current_code(target, None)
 
 
 class TestExtractCurrentCodeLine:
@@ -128,14 +128,18 @@ class TestResolveLineRangeSymbol:
         # my_func starts at line 2 and ends at line 3
         assert result == (2, 3)
 
-    def test_symbol_not_found_returns_none(self, tmp_path: Path) -> None:
+    def test_symbol_not_found_raises(self, tmp_path: Path) -> None:
+        """_resolve_line_range must raise SymbolNotFoundError for missing symbols.
+
+        The error propagates to the CLI so the user sees an explicit message
+        instead of a silent fallback to file-scoped history.
+        """
         content = "def exists():\n    pass\n"
         f = _make_py_file(tmp_path, "sample.py", content)
         target = Target(file=f, symbol="ghost")
 
-        result = _resolve_line_range(target)
-
-        assert result is None
+        with pytest.raises(SymbolNotFoundError):
+            _resolve_line_range(target)
 
 
 class TestResolveLineRangeLine:
@@ -701,10 +705,9 @@ class TestSynthesizeWhyStrictMode:
                 _PATCH_VALIDATE_CITATIONS,
                 side_effect=ValueError("citation validation failed: 1 issues"),
             ) as mock_validate,
+            pytest.raises(ValueError, match="citation validation failed"),
         ):
-            import pytest
-            with pytest.raises(ValueError, match="citation validation failed"):
-                synthesize_why(target, tmp_path, llm, strict=True)
+            synthesize_why(target, tmp_path, llm, strict=True)
 
         # Confirm strict=True was forwarded to validate_citations as a keyword argument.
         mock_validate.assert_called_once()


### PR DESCRIPTION
## Related Links
- Closes #18
- Depends on #8 (tree-sitter symbol range resolver), #16 (whole-file CLI entry)

## What
- Wires the `why <file> <symbol>` CLI form end-to-end so `why src/foo.py authenticate_user` resolves the symbol range via tree-sitter and runs line-scoped git history over it
- Propagates `SymbolNotFoundError` to the CLI (exit 1 + `Error:` message) instead of silently falling back to file-scoped history
- Removes the dead `line_range=None` fallback branch in `_extract_current_code` and replaces it with an explicit assertion

## Why
Issue #18 acceptance criteria require a clear error when a symbol isn't found. The previous silent fallback produced a misleading successful output for a mistyped symbol name.

## How
- `synth.py`: removed `try/except SymbolNotFoundError` in `_resolve_line_range` — error now propagates naturally up the call stack
- `cli.py`: added `SymbolNotFoundError` to the `except (LLMError, GitError, SymbolNotFoundError)` clause
- `synth.py _extract_current_code`: replaced unreachable `if line_range is None: return full_file` branch with `assert line_range is not None` to make the invariant explicit
- `conftest.py`: extracted duplicated git version detection boilerplate into `init_git_main_branch()` helper

## Test Steps
- `uv run pytest -x -q` → 179 passed
- `uv run ruff check src/ tests/` → all checks passed
- New `TestSymbolTargetEndToEnd` class covers:
  - Happy path (`why auth.py authenticate_user` end-to-end with real git repo + mocked LLM, including `find_symbol_range` spy)
  - Error path (`why foo.py nonexistent_func` → exit 1, `Error:` in output)

## Other Notes
- TypeScript symbol support is out of scope per design decision; Python and Go are supported via existing `symbols.py`