### PR TITLE
feat: surface structural design decisions when git history is sparse

### DIFF
--- a/src/why/prompts.py
+++ b/src/why/prompts.py
@@ -8,7 +8,8 @@ from why.commit import Commit
 from why.llm import Message
 from why.target import Target
 
-# Inject the sparse-history notice when key_commits is strictly below this count (0–2 triggers; 3+ suppresses).
+# Inject the sparse-history notice when key_commits is strictly below this count
+# (0-2 triggers the notice; 3+ suppresses it).
 SPARSE_COMMIT_THRESHOLD: int = 3
 
 # ---------------------------------------------------------------------------
@@ -61,7 +62,8 @@ You will be given:
 - Every reason MUST be labeled:
   - [STATED] → explicitly written in commit/PR
   - [INFERRED] → deduced from diff patterns
-  - [STRUCTURAL] → deduced from code structure (naming, constants, separation of concerns, invariants, defensive patterns) — only valid when a Sparse History Notice is present
+  - [STRUCTURAL] → deduced from code structure (naming, constants, separation of concerns,
+    invariants, defensive patterns) — only valid when a Sparse History Notice is present
 - If a statement has no tag → DO NOT include it.
 
 3. NO HALLUCINATION GUARANTEE
@@ -273,7 +275,7 @@ def build_why_prompt(
     commits_section = f"## Commits\n\n{commits_body}" if commits_body else "## Commits"
 
     # Sparse-history notice: instruct LLM to inspect code structure when commits < threshold.
-    # 0 commits gets distinct wording (no mention of "0 commit(s)"); 1–2 gets count-aware wording.
+    # 0 commits gets distinct wording (no mention of "0 commit(s)"); 1-2 gets count-aware wording.
     sparse_sections = []
     if len(key_commits) < SPARSE_COMMIT_THRESHOLD:
         n = len(key_commits)
@@ -302,7 +304,7 @@ def build_why_prompt(
     # Sparse notice is placed before commits so that "## Commits" remains the final
     # section when key_commits is empty, preserving the invariant that there is no
     # trailing "\n\n" after the commits header in the empty case.
-    all_sections = [target_section, code_section] + sparse_sections + [commits_section]
+    all_sections = [target_section, code_section, *sparse_sections, commits_section]
     content = "\n\n---\n\n".join(all_sections)
 
     return [Message(role="user", content=content)]

--- a/src/why/prompts.py
+++ b/src/why/prompts.py
@@ -8,14 +8,19 @@ from why.commit import Commit
 from why.llm import Message
 from why.target import Target
 
+# Inject the sparse-history notice when key_commits is strictly below this count (0–2 triggers; 3+ suppresses).
+SPARSE_COMMIT_THRESHOLD: int = 3
+
 # ---------------------------------------------------------------------------
 # System prompt (verbatim — do not modify formatting)
 # ---------------------------------------------------------------------------
 
 WHY_SYSTEM_PROMPT: str = """You are a code archaeology assistant.
 
-Your job is to explain WHY a piece of code exists in its current form,
-using ONLY its Git commit history and Pull Request (PR) history.
+Your job is to explain WHY a piece of code exists in its current form.
+Your primary sources are Git commit history and Pull Request (PR) history.
+When the history is sparse, you may also analyse the code structure itself
+to surface design decisions implied by the code but not recorded in commits.
 
 You are answering a developer who is currently reading this code and wondering:
 "why is it written like this?"
@@ -41,6 +46,7 @@ You will be given:
 - Code snippet (function, file, or line range)
 - Relevant commits (hash, message, diff)
 - Related PRs (title, description, discussion)
+- (When history is sparse) A "Sparse History Notice" — signals that structural analysis is expected
 
 ---
 
@@ -51,10 +57,11 @@ You will be given:
 - If no supporting evidence exists, write exactly:
   "No evidence found in history."
 
-2. STATED vs INFERRED (MANDATORY TAGGING)
+2. STATED vs INFERRED vs STRUCTURAL (MANDATORY TAGGING)
 - Every reason MUST be labeled:
   - [STATED] → explicitly written in commit/PR
   - [INFERRED] → deduced from diff patterns
+  - [STRUCTURAL] → deduced from code structure (naming, constants, separation of concerns, invariants, defensive patterns) — only valid when a Sparse History Notice is present
 - If a statement has no tag → DO NOT include it.
 
 3. NO HALLUCINATION GUARANTEE
@@ -98,6 +105,14 @@ You will be given:
 ---
 
 ### ⚠️ Gaps / Uncertainty
+- ...
+
+---
+
+### 🏗️ Structural Observations
+(Present only when a Sparse History Notice is included in the inputs.
+ List design decisions implied by the code structure, not by commit history.
+ Each point must be tagged [STRUCTURAL] and must NOT duplicate what commits already explain.)
 - ...
 
 ---
@@ -257,7 +272,37 @@ def build_why_prompt(
     commits_body = "\n\n".join(_render_commit(cwpr) for cwpr in key_commits)
     commits_section = f"## Commits\n\n{commits_body}" if commits_body else "## Commits"
 
-    # Join all sections with horizontal-rule separators
-    content = "\n\n---\n\n".join([target_section, code_section, commits_section])
+    # Sparse-history notice: instruct LLM to inspect code structure when commits < threshold.
+    # 0 commits gets distinct wording (no mention of "0 commit(s)"); 1–2 gets count-aware wording.
+    sparse_sections = []
+    if len(key_commits) < SPARSE_COMMIT_THRESHOLD:
+        n = len(key_commits)
+        if n == 0:
+            sparse_notice = (
+                "## Sparse History Notice\n\n"
+                "No git history is available for this region. "
+                "Analyse the code structure itself and surface design decisions implied by "
+                "the code. Look for: naming conventions, separation of concerns, "
+                "module-level constants, defensive patterns, and invariants. "
+                "Tag all findings [STRUCTURAL]."
+            )
+        else:
+            sparse_notice = (
+                f"## Sparse History Notice\n\n"
+                f"The git history for this region is sparse ({n} commit(s)). "
+                f"In addition to explaining what the commits show, analyse the code "
+                f"structure itself and surface any design decisions implied by the code "
+                f"but not explained by the commit messages. Look for: naming conventions, "
+                f"separation of concerns, module-level constants, defensive patterns, and "
+                f"invariants. Distinguish commit-backed reasoning from structural inference."
+            )
+        sparse_sections = [sparse_notice]
+
+    # Join all sections with horizontal-rule separators.
+    # Sparse notice is placed before commits so that "## Commits" remains the final
+    # section when key_commits is empty, preserving the invariant that there is no
+    # trailing "\n\n" after the commits header in the empty case.
+    all_sections = [target_section, code_section] + sparse_sections + [commits_section]
+    content = "\n\n---\n\n".join(all_sections)
 
     return [Message(role="user", content=content)]

--- a/tests/fixtures/prompts/why_prompt_golden.txt
+++ b/tests/fixtures/prompts/why_prompt_golden.txt
@@ -13,6 +13,12 @@ def score_commit(c: Commit, now: date, has_pr: bool) -> float:
 
 ---
 
+## Sparse History Notice
+
+The git history for this region is sparse (1 commit(s)). In addition to explaining what the commits show, analyse the code structure itself and surface any design decisions implied by the code but not explained by the commit messages. Look for: naming conventions, separation of concerns, module-level constants, defensive patterns, and invariants. Distinguish commit-backed reasoning from structural inference.
+
+---
+
 ## Commits
 
 ### `abc1234` — "fix: handle null token in auth check" · 2026-01-15 · Jane Smith

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from why.commit import Commit
 from why.llm import Message
-from why.prompts import WHY_SYSTEM_PROMPT, CommitWithPR, build_why_prompt
+from why.prompts import WHY_SYSTEM_PROMPT, CommitWithPR, build_why_prompt, SPARSE_COMMIT_THRESHOLD
 from why.target import Target
 
 # ---------------------------------------------------------------------------
@@ -281,3 +281,57 @@ def test_target_with_line_and_symbol() -> None:
     target = Target(file=Path("src/why/scoring.py"), line=42, symbol="score_commit")
     result = build_why_prompt(target, FIXED_CURRENT_CODE, [])
     assert "File: `src/why/scoring.py`, Line: 42, Symbol: `score_commit`" in result[0].content
+
+
+# ---------------------------------------------------------------------------
+# Sparse-history injection tests
+# ---------------------------------------------------------------------------
+
+def test_sparse_history_notice_injected_when_few_commits() -> None:
+    """When len(key_commits) < SPARSE_COMMIT_THRESHOLD, a sparse-history notice must appear in the user message."""
+    # Use 2 distinct commits (below threshold of 3) to verify dynamic count
+    second_commit = Commit(
+        sha="def5678abc1234901234567890",
+        author_name="Jane Smith",
+        author_email="jane@example.com",
+        date=FIXED_DATE,
+        subject="chore: second commit",
+        body="",
+        parents=("aaabbbccc",),
+    )
+    commits = [CommitWithPR(commit=FIXED_COMMIT), CommitWithPR(commit=second_commit)]
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
+    content = result[0].content
+    assert "## Sparse History Notice" in content
+    assert "structural" in content.lower()  # instruction must mention structural analysis
+    assert "2 commit(s)" in content  # count must be dynamic, not hardcoded
+    # Sparse notice must appear before the commits section
+    assert content.index("## Sparse History Notice") < content.index("## Commits")
+
+
+def test_sparse_history_notice_absent_when_enough_commits() -> None:
+    """When len(key_commits) >= SPARSE_COMMIT_THRESHOLD, NO sparse-history notice must appear."""
+    commits = [CommitWithPR(commit=FIXED_COMMIT) for _ in range(3)]
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
+    content = result[0].content
+    assert "## Sparse History Notice" not in content
+
+
+def test_sparse_history_notice_zero_commits_wording() -> None:
+    """When there are 0 commits, the sparse notice must not say '0 commit(s)' — use distinct wording."""
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [])
+    content = result[0].content
+    assert "## Sparse History Notice" in content
+    assert "0 commit(s)" not in content
+    assert "No git history is available" in content
+
+
+# ---------------------------------------------------------------------------
+# System prompt structural-analysis tests
+# ---------------------------------------------------------------------------
+
+def test_system_prompt_structural_contract() -> None:
+    """WHY_SYSTEM_PROMPT must define structural analysis: evidence allowed, [STRUCTURAL] tag, and output section."""
+    assert "structural" in WHY_SYSTEM_PROMPT.lower()
+    assert "[STRUCTURAL]" in WHY_SYSTEM_PROMPT
+    assert "Structural Observations" in WHY_SYSTEM_PROMPT

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from why.commit import Commit
 from why.llm import Message
-from why.prompts import WHY_SYSTEM_PROMPT, CommitWithPR, build_why_prompt, SPARSE_COMMIT_THRESHOLD
+from why.prompts import WHY_SYSTEM_PROMPT, CommitWithPR, build_why_prompt
 from why.target import Target
 
 # ---------------------------------------------------------------------------
@@ -288,7 +288,7 @@ def test_target_with_line_and_symbol() -> None:
 # ---------------------------------------------------------------------------
 
 def test_sparse_history_notice_injected_when_few_commits() -> None:
-    """When len(key_commits) < SPARSE_COMMIT_THRESHOLD, a sparse-history notice must appear in the user message."""
+    """Sparse-history notice must appear when len(key_commits) < SPARSE_COMMIT_THRESHOLD."""
     # Use 2 distinct commits (below threshold of 3) to verify dynamic count
     second_commit = Commit(
         sha="def5678abc1234901234567890",
@@ -318,7 +318,7 @@ def test_sparse_history_notice_absent_when_enough_commits() -> None:
 
 
 def test_sparse_history_notice_zero_commits_wording() -> None:
-    """When there are 0 commits, the sparse notice must not say '0 commit(s)' — use distinct wording."""
+    """Zero commits must render distinct wording, not '0 commit(s)'."""
     result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [])
     content = result[0].content
     assert "## Sparse History Notice" in content
@@ -331,7 +331,7 @@ def test_sparse_history_notice_zero_commits_wording() -> None:
 # ---------------------------------------------------------------------------
 
 def test_system_prompt_structural_contract() -> None:
-    """WHY_SYSTEM_PROMPT must define structural analysis: evidence allowed, [STRUCTURAL] tag, and output section."""
+    """WHY_SYSTEM_PROMPT must allow structural evidence, [STRUCTURAL] tag, and output section."""
     assert "structural" in WHY_SYSTEM_PROMPT.lower()
     assert "[STRUCTURAL]" in WHY_SYSTEM_PROMPT
     assert "Structural Observations" in WHY_SYSTEM_PROMPT


### PR DESCRIPTION
## Related Links
- Closes #67

## What
Adds a sparse-history path to `build_why_prompt` that fires when `len(key_commits) < SPARSE_COMMIT_THRESHOLD` (< 3 commits). When triggered, a `## Sparse History Notice` section is injected into the user message instructing the LLM to analyse code structure itself — naming conventions, module-level constants, separation of concerns, invariants, and defensive patterns — rather than padding thin commit history with filler.

## Why
`why` output quality was bounded by commit granularity. A function written in a single large commit produced a one-line changelog entry, not a design explanation. The interesting decisions (why `_PARSERS` is module-level, why `_LINE_WINDOW = 20`, why `_resolve_line_range` is separated) live in the code, not in commit messages.

## How
- `SPARSE_COMMIT_THRESHOLD = 3` constant in `prompts.py` — 0–2 commits triggers the notice, 3+ suppresses it
- 0-commit case gets distinct wording ("No git history is available") instead of grammatically awkward "0 commit(s)"
- `WHY_SYSTEM_PROMPT` expanded: opening sentence allows structural evidence, `[STRUCTURAL]` tag added alongside `[STATED]`/`[INFERRED]`, `### 🏗️ Structural Observations` section added to output format
- Sparse notice placed before `## Commits` section so the section-join invariant holds when commit list is empty

## Test Steps
- [ ] `uv run pytest tests/test_prompts.py -v` — 22 tests, all green
- [ ] `uv run pytest tests/ -v` — 183 tests, all green
- [ ] `why src/why/synth.py synthesize_why` (single-commit function) should now mention at least one structural observation not sourced from a commit message

## Other Notes
Golden fixture regenerated to reflect the new sparse notice for the 1-commit test scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)