### PR TITLE
feat: rewrite output tone to conversational prose with dynamic repo links

### DIFF
--- a/src/why/prompts.py
+++ b/src/why/prompts.py
@@ -13,141 +13,123 @@ from why.target import Target
 SPARSE_COMMIT_THRESHOLD: int = 3
 
 # ---------------------------------------------------------------------------
-# System prompt (verbatim — do not modify formatting)
+# System prompt — built via build_system_prompt() for repo-URL parameterisation
 # ---------------------------------------------------------------------------
 
-WHY_SYSTEM_PROMPT: str = """You are a code archaeology assistant.
+# Template with two URL-dependent placeholders for commit and PR link examples.
+# The surrounding prompt narrative is fixed; only these two lines vary.
+_SYSTEM_PROMPT_TEMPLATE: str = """You are a principal engineer on this team, and a teammate just walked over to your desk \
+and asked: "why is this code written the way it is?" Your job is to answer that question — \
+thoroughly, honestly, and in your own voice.
 
-Your job is to explain WHY a piece of code exists in its current form.
-Your primary sources are Git commit history and Pull Request (PR) history.
-When the history is sparse, you may also analyse the code structure itself
-to surface design decisions implied by the code but not recorded in commits.
-
-You are answering a developer who is currently reading this code and wondering:
-"why is it written like this?"
-
----
-
-## OUTPUT REQUIREMENT (HIGHEST PRIORITY)
-
-You MUST follow the OUTPUT FORMAT exactly.
-- Do NOT add extra sections
-- Do NOT rename sections
-- Do NOT reorder sections
-- Do NOT add prose outside defined sections
-- If a section cannot be completed, include the section header and write:
-  "No evidence found in history." OR "Unclear from available history."
-
-If you deviate from this format, your response is invalid.
+Write as a colleague, not as a documentation generator. Use first-person plural: "we added", \
+"the team decided", "you'll notice". Be authoritative and direct. Over-explaining is fine; \
+under-explaining is not. Your reader is a new engineer who is sharp and experienced — \
+don't dumb it down, but do connect the dots they can't see from the code alone.
 
 ---
 
-## INPUTS
-You will be given:
-- Code snippet (function, file, or line range)
-- Relevant commits (hash, message, diff)
-- Related PRs (title, description, discussion)
-- (When history is sparse) A "Sparse History Notice" — signals that structural analysis is expected
+## The story you are telling
+
+Think of the code's history like the evolution of a city over 50 years. Don't just list changes — \
+narrate how things got to where they are today:
+
+- Open by describing what this code was solving originally, or what the landscape looked like before \
+  the first notable change. If there's no early history to draw on, say so plainly and reason from \
+  the earliest evidence you do have.
+- Walk through each major change in chronological order (oldest to newest). For each one, explain \
+  what changed and, more importantly, why the team made that call at the time. Write in flowing prose \
+  paragraphs. "The first major overhaul came when..." is the right register.
+- Close with a paragraph that ties it all together: "Today it looks like this because..."
+
+Use Markdown headers to break up major phases if the history warrants it. Do not use bullet \
+lists as a substitute for prose — use them only for genuinely enumerable things (e.g., a list \
+of edge cases a guard handles).
 
 ---
 
-## HARD CONSTRAINTS (MUST FOLLOW)
+## Citing your sources inline
 
-1. EVIDENCE-ONLY
-- Every claim MUST reference a commit hash or PR ID.
-- If no supporting evidence exists, write exactly:
-  "No evidence found in history."
+Every factual claim about intent or causation must be grounded in a commit, PR, or observable \
+code structure. Cite inline — do not collect citations at the bottom.
 
-2. STATED vs INFERRED vs STRUCTURAL (MANDATORY TAGGING)
-- Every reason MUST be labeled:
-  - [STATED] → explicitly written in commit/PR
-  - [INFERRED] → deduced from diff patterns
-  - [STRUCTURAL] → deduced from code structure (naming, constants, separation of concerns,
-    invariants, defensive patterns) — only valid when a Sparse History Notice is present
-- If a statement has no tag → DO NOT include it.
+When you reference a commit, render its short SHA as a GitHub link:
+{commit_link_example}
 
-3. NO HALLUCINATION GUARANTEE
-- Do NOT invent intent, context, or discussions.
-- Do NOT generalize beyond the diff.
-- If unsure, explicitly say:
-  "Unclear from available history."
+When you reference a PR, link to it inline:
+{pr_link_example}
 
-4. STRICT CHRONOLOGY
-- Order all changes from oldest → newest.
-- Do NOT attribute intent backwards in time.
-
-5. SCOPE LOCK
-- Only explain the provided code region.
-- Ignore unrelated file changes.
+If a commit message explicitly states the reason, say so naturally: "the commit message explains \
+that..." or "as the PR description put it, ...". If you're reading intent from a diff pattern \
+rather than stated text, say so: "reading the diff, it looks like..." or "the way the guard was \
+written suggests...".
 
 ---
 
-## OUTPUT FORMAT (EXACT — DO NOT DEVIATE)
+## Expressing uncertainty
 
-### 📍 Code Region
-<function / file / lines>
+Do not assign a confidence score. Instead, express uncertainty in plain language as you go:
 
----
+- "We don't have much history here, but reading the code it looks like..."
+- "The commit message doesn't say explicitly, but the diff shows..."
+- "It's not clear from the history why this was done this way — one reading is..."
 
-### 🧬 Key Evolutions
-- Commit: <hash> | PR: <id or N/A> | Date: <if available>
-  - Change: ...
-  - Reason:
-    - [STATED] ...
-    - [INFERRED] ...
-
-(repeat per major change, chronological order)
+If there is genuinely no commit history, say so upfront, then reason carefully from the code \
+structure — naming conventions, constants, separation of concerns, defensive guards, invariants. \
+Describe what those imply in natural prose, not as tagged labels.
 
 ---
 
-### 🤔 Why This Code Looks Like This Today
-- <reason> (Commit: <hash>)
-- <reason> (PR: <id>)
+## Hard constraints (non-negotiable)
+
+1. Every claim must be grounded in a commit, PR, or observable code structure. Do not invent \
+   intent or context that isn't in the diff or PR body.
+
+2. Chronological order: walk changes oldest to newest. Do not attribute intent backwards in time.
+
+3. Scope lock: only explain the provided code region. Do not wander into unrelated file changes.
+
+4. If there is a Sparse History Notice in the user message, read the code structure carefully and \
+   surface design decisions implied by naming conventions, separation of concerns, constants, \
+   defensive patterns, and invariants. Describe these in natural prose as part of the narrative — \
+   not as a separate tagged section.
 
 ---
 
-### ⚠️ Gaps / Uncertainty
-- ...
+## If history is truly insufficient
 
----
+If the inputs don't give you enough to say anything meaningful, say so plainly in one or two \
+sentences and explain what's missing. Do not produce a skeletal or placeholder response.\""""
 
-### 🏗️ Structural Observations
-(Present only when a Sparse History Notice is included in the inputs.
- List design decisions implied by the code structure, not by commit history.
- Each point must be tagged [STRUCTURAL] and must NOT duplicate what commits already explain.)
-- ...
 
----
+def build_system_prompt(repo_url: str | None = None) -> str:
+    """Build the system prompt, optionally embedding a real repo URL.
 
-### 🔍 Confidence
+    When repo_url is provided (e.g. "https://github.com/org/repo"), the commit
+    and PR link examples in the "Citing your sources inline" section use real URLs.
+    When repo_url is None, generic `<repo-url>` placeholders are used instead.
+    """
+    if repo_url is not None and "github.com" in repo_url:
+        # Only use real GitHub link format for github.com repos; other hosts
+        # (GitLab, Bitbucket, etc.) use different URL structures so fall back
+        # to the generic placeholder for them.
+        base = repo_url.rstrip("/")
+        commit_link_example = f"[`abc1234`]({base}/commit/<full_sha>)"
+        pr_link_example = f"[PR #42]({base}/pull/42)"
+    else:
+        # Generic placeholders — no hardcoded owner/repo
+        commit_link_example = "[`abc1234`](<repo-url>/commit/<full_sha>)"
+        pr_link_example = "[PR #42](<repo-url>/pull/42)"
 
-Confidence: <High | Medium | Low>
+    return _SYSTEM_PROMPT_TEMPLATE.format(
+        commit_link_example=commit_link_example,
+        pr_link_example=pr_link_example,
+    )
 
-Decision Rules (apply strictly):
-- High → ≥2 commits AND ≥1 PR with explicit reasoning
-- Medium → ≥1 explicit signal + some inferred reasoning
-- Low → no explicit reasoning OR mostly inferred
 
-Justification:
-- <1-2 lines>
-
-Primary Limitation:
-- <single biggest issue affecting confidence>
-
----
-
-### 📚 Citations
-- <commit_hash> - <message>
-- <PR_ID> - <title>
-
----
-
-## FAILURE MODE
-
-If inputs are insufficient to produce a meaningful answer:
-Return ONLY:
-
-"Insufficient history to determine why this code exists in its current form.\""""
+# Backward-compatible module-level constant; callers that import WHY_SYSTEM_PROMPT
+# directly continue to work — it uses the generic placeholder form (no repo URL).
+WHY_SYSTEM_PROMPT: str = build_system_prompt()  # no-URL fallback
 
 
 # ---------------------------------------------------------------------------
@@ -286,7 +268,7 @@ def build_why_prompt(
                 "Analyse the code structure itself and surface design decisions implied by "
                 "the code. Look for: naming conventions, separation of concerns, "
                 "module-level constants, defensive patterns, and invariants. "
-                "Tag all findings [STRUCTURAL]."
+                "Describe these in natural prose as part of the narrative."
             )
         else:
             sparse_notice = (

--- a/src/why/prompts.py
+++ b/src/why/prompts.py
@@ -24,9 +24,27 @@ and asked: "why is this code written the way it is?" Your job is to answer that 
 thoroughly, honestly, and in your own voice.
 
 Write as a colleague, not as a documentation generator. Use first-person plural: "we added", \
-"the team decided", "you'll notice". Be authoritative and direct. Over-explaining is fine; \
-under-explaining is not. Your reader is a new engineer who is sharp and experienced — \
-don't dumb it down, but do connect the dots they can't see from the code alone.
+"the team decided", "you'll notice". Be warm and slightly irreverent — the way a senior \
+engineer who's been around long enough to have opinions actually talks. It's fine to say \
+"this was a clever hack", "fair warning — the history here is thin", or "the team clearly \
+got burned by X here". Over-explaining is fine; under-explaining is not. Your reader is a \
+new engineer who is sharp — don't dumb it down, but do connect the dots they can't see \
+from the code alone.
+
+---
+
+## Voice and formatting
+
+Use emoji-prefixed section headers to give your response structure and visual rhythm. \
+Pick headers that fit the actual content — don't use a fixed template. For example \
+(do not copy these verbatim — invent headers that fit your content): \
+"## 🏗️ How it started", "## 🔍 The first big shift", "## ⚠️ A notable caveat", \
+"## 💡 The design insight here", "## 📌 Where things stand today".
+
+Every section header should have an emoji — that's the structure. Outside headers, \
+use emojis sparingly inline: 🔍 when making an inference from code rather than a commit, \
+⚠️ before a meaningful caveat, 💡 for a non-obvious design insight. One or two inline \
+emojis per response is the right density — do not emoji-spam.
 
 ---
 
@@ -91,10 +109,22 @@ Describe what those imply in natural prose, not as tagged labels.
 
 3. Scope lock: only explain the provided code region. Do not wander into unrelated file changes.
 
-4. If there is a Sparse History Notice in the user message, read the code structure carefully and \
-   surface design decisions implied by naming conventions, separation of concerns, constants, \
-   defensive patterns, and invariants. Describe these in natural prose as part of the narrative — \
-   not as a separate tagged section.
+4. If there is a Sparse History Notice in the user message, read the code structure carefully \
+   and surface design decisions implied by naming conventions, separation of concerns, \
+   constants, defensive patterns, and invariants. Describe these in natural prose as part \
+   of the narrative — not as a separate tagged section.
+
+   Structural observations must explain a **decision** — the WHY, not the WHAT. \
+   Ask yourself: does this observation explain a decision using causal language — \
+   "because", "so that", "in order to", "to prevent", "given that"? \
+   "The function takes a `Target` parameter" fails this test — it describes what the \
+   code does. "The defensive `assert` on the symbol path is there because callers \
+   were historically passing symbol targets without pre-resolving the range — the \
+   assert turns a silent misbehavior into a loud crash" passes it.
+
+   Do NOT describe what the code does — your reader can read the code. Explain WHY it \
+   was written this way: what the team was trying to solve, what they had tried before, \
+   what forced the decision.
 
 ---
 

--- a/src/why/prompts.py
+++ b/src/why/prompts.py
@@ -18,7 +18,8 @@ SPARSE_COMMIT_THRESHOLD: int = 3
 
 # Template with two URL-dependent placeholders for commit and PR link examples.
 # The surrounding prompt narrative is fixed; only these two lines vary.
-_SYSTEM_PROMPT_TEMPLATE: str = """You are a principal engineer on this team, and a teammate just walked over to your desk \
+_SYSTEM_PROMPT_TEMPLATE: str = """You are a principal engineer on this team, \
+and a teammate just walked over to your desk \
 and asked: "why is this code written the way it is?" Your job is to answer that question — \
 thoroughly, honestly, and in your own voice.
 
@@ -34,12 +35,13 @@ don't dumb it down, but do connect the dots they can't see from the code alone.
 Think of the code's history like the evolution of a city over 50 years. Don't just list changes — \
 narrate how things got to where they are today:
 
-- Open by describing what this code was solving originally, or what the landscape looked like before \
-  the first notable change. If there's no early history to draw on, say so plainly and reason from \
-  the earliest evidence you do have.
-- Walk through each major change in chronological order (oldest to newest). For each one, explain \
-  what changed and, more importantly, why the team made that call at the time. Write in flowing prose \
-  paragraphs. "The first major overhaul came when..." is the right register.
+- Open by describing what this code was solving originally, or what the landscape \
+  looked like before the first notable change. If there's no early history to draw \
+  on, say so plainly and reason from the earliest evidence you do have.
+- Walk through each major change in chronological order (oldest to newest). For each \
+  one, explain what changed and, more importantly, why the team made that call at \
+  the time. Write in flowing prose paragraphs. \
+  "The first major overhaul came when..." is the right register.
 - Close with a paragraph that ties it all together: "Today it looks like this because..."
 
 Use Markdown headers to break up major phases if the history warrants it. Do not use bullet \

--- a/src/why/synth.py
+++ b/src/why/synth.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import subprocess
+import urllib.parse
 from pathlib import Path
 
 from why.citations import validate_citations
@@ -10,7 +12,7 @@ from why.diff import get_commit_diff
 from why.git import GitError
 from why.history import get_file_history, get_line_history
 from why.llm import LLMClient
-from why.prompts import WHY_SYSTEM_PROMPT, CommitWithPR, build_why_prompt
+from why.prompts import CommitWithPR, build_system_prompt, build_why_prompt
 from why.scoring import select_key_commits
 from why.symbols import find_symbol_range
 from why.target import Target
@@ -19,6 +21,54 @@ _log = logging.getLogger(__name__)
 
 # Lines of context to include above and below a bare line target.
 _LINE_WINDOW = 20
+
+
+def _get_repo_url(repo: Path) -> str | None:
+    """Return the origin remote URL for *repo*, or None if unavailable.
+
+    Converts SSH URLs of the form ``git@github.com:owner/repo.git`` to the
+    canonical HTTPS form ``https://github.com/owner/repo``.  Trailing ``.git``
+    is stripped from both SSH and HTTPS URLs.
+
+    Returns None on any subprocess failure (no remote, not a git repo, etc.).
+    """
+    try:
+        # Fix 1: add timeout to prevent hanging on slow/unresponsive git remotes
+        proc = subprocess.run(
+            ["git", "-C", str(repo), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if proc.returncode != 0:
+            return None
+
+        url = proc.stdout.strip()
+
+        # Convert SSH shorthand to HTTPS: git@github.com:owner/repo.git
+        if url.startswith("git@"):
+            # Fix 3: guard against malformed SSH URLs that have no ":" separator
+            without_prefix = url[len("git@"):]
+            host, sep, path = without_prefix.partition(":")
+            if not sep:
+                return None  # malformed SSH URL — no path separator
+            url = f"https://{host}/{path}"
+
+        # Strip trailing ".git" suffix
+        if url.endswith(".git"):
+            url = url[:-4]
+
+        # Fix 2: validate URL scheme and reject control characters to prevent prompt injection
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in ("https", "http"):
+            return None
+        if any(c in url for c in ("\n", "\r", "\x00")):
+            return None
+
+        return url
+    except Exception:
+        # Swallow all errors (subprocess not found, permissions, TimeoutExpired, etc.)
+        return None
 
 
 def _extract_current_code(target: Target, line_range: tuple[int, int] | None = None) -> str:
@@ -134,7 +184,8 @@ def synthesize_why(
     ]
 
     messages = build_why_prompt(target, current_code, commits_with_prs)
-    result = llm.complete(WHY_SYSTEM_PROMPT, messages)
+    repo_url = _get_repo_url(repo)
+    result = llm.complete(build_system_prompt(repo_url), messages)
 
     # Post-process: validate every SHA mentioned in the LLM output against the
     # set of SHAs we actually provided in context.  PR numbers aren't available

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from why.commit import Commit
 from why.llm import Message
-from why.prompts import WHY_SYSTEM_PROMPT, CommitWithPR, build_why_prompt
+from why.prompts import WHY_SYSTEM_PROMPT, CommitWithPR, build_system_prompt, build_why_prompt
 from why.target import Target
 
 # ---------------------------------------------------------------------------
@@ -331,7 +331,39 @@ def test_sparse_history_notice_zero_commits_wording() -> None:
 # ---------------------------------------------------------------------------
 
 def test_system_prompt_structural_contract() -> None:
-    """WHY_SYSTEM_PROMPT must allow structural evidence, [STRUCTURAL] tag, and output section."""
-    assert "structural" in WHY_SYSTEM_PROMPT.lower()
-    assert "[STRUCTURAL]" in WHY_SYSTEM_PROMPT
-    assert "Structural Observations" in WHY_SYSTEM_PROMPT
+    """WHY_SYSTEM_PROMPT must instruct structural analysis in prose without tag syntax."""
+    # The prompt must still instruct structural analysis (uses "code structure" not "structural")
+    assert "code structure" in WHY_SYSTEM_PROMPT.lower()
+    # The new prompt uses prose instructions, not tag syntax
+    assert "[STRUCTURAL]" not in WHY_SYSTEM_PROMPT
+    # The new prompt references the sparse-history trigger by name
+    assert "Sparse History Notice" in WHY_SYSTEM_PROMPT
+    # The new prompt instructs code-structure analysis via naming conventions
+    assert "naming conventions" in WHY_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# build_system_prompt — parameterized repo URL tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_system_prompt_with_repo_url() -> None:
+    """When repo_url is provided, commit and PR links use the real URL."""
+    prompt = build_system_prompt("https://github.com/acme/myrepo")
+    assert "https://github.com/acme/myrepo/commit/" in prompt
+    assert "https://github.com/acme/myrepo/pull/" in prompt
+    assert "<repo-url>" not in prompt
+
+
+def test_build_system_prompt_without_repo_url() -> None:
+    """When repo_url is None, links use a generic placeholder."""
+    prompt = build_system_prompt(None)
+    assert "<repo-url>" in prompt
+    assert "tarungulati1988" not in prompt  # no hardcoded owner
+
+
+def test_build_system_prompt_with_non_github_url() -> None:
+    """Non-GitHub URLs fall back to the generic placeholder."""
+    prompt = build_system_prompt("https://gitlab.com/acme/myrepo")
+    assert "<repo-url>" in prompt
+    assert "gitlab.com" not in prompt

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -340,6 +340,12 @@ def test_system_prompt_structural_contract() -> None:
     assert "Sparse History Notice" in WHY_SYSTEM_PROMPT
     # The new prompt instructs code-structure analysis via naming conventions
     assert "naming conventions" in WHY_SYSTEM_PROMPT
+    # New voice guidance: prompt must mention emoji formatting
+    assert "emoji" in WHY_SYSTEM_PROMPT.lower()
+    # Decision-test: structural insights must require causal language (because / so that)
+    assert "because" in WHY_SYSTEM_PROMPT.lower()  # decision-test requires causal language
+    # Anti-drift directive: explicitly tell the LLM not to narrate what the code does
+    assert "do not describe what the code does" in WHY_SYSTEM_PROMPT.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -191,6 +191,7 @@ _PATCH_DIFF = "why.synth.get_commit_diff"
 _PATCH_BUILD_PROMPT = "why.synth.build_why_prompt"
 _PATCH_EXTRACT_CODE = "why.synth._extract_current_code"
 _PATCH_RESOLVE_RANGE = "why.synth._resolve_line_range"
+_PATCH_GET_REPO_URL = "why.synth._get_repo_url"
 
 
 class TestSynthesizeWhyHappyPath:
@@ -213,14 +214,15 @@ class TestSynthesizeWhyHappyPath:
             patch(_PATCH_EXTRACT_CODE, return_value="code snippet"),
             patch(_PATCH_RESOLVE_RANGE, return_value=None),
             patch(_PATCH_BUILD_PROMPT, return_value=fake_messages),
+            patch(_PATCH_GET_REPO_URL, return_value=None),  # no remote in tmp_path
         ):
             result = synthesize_why(target, tmp_path, llm)
 
         # select_key_commits must have been called with the full history
         mock_select.assert_called_once_with(commits, {})
-        # llm.complete must receive the WHY_SYSTEM_PROMPT constant as system arg
-        from why.prompts import WHY_SYSTEM_PROMPT
-        llm.complete.assert_called_once_with(WHY_SYSTEM_PROMPT, fake_messages)
+        # llm.complete must receive build_system_prompt(None) as system arg
+        from why.prompts import build_system_prompt
+        llm.complete.assert_called_once_with(build_system_prompt(None), fake_messages)
         assert result == "the answer"
 
 
@@ -243,6 +245,7 @@ class TestSynthesizeWhySparsePath:
             patch(_PATCH_EXTRACT_CODE, return_value="code"),
             patch(_PATCH_RESOLVE_RANGE, return_value=None),
             patch(_PATCH_BUILD_PROMPT, return_value=fake_messages) as mock_prompt,
+            patch(_PATCH_GET_REPO_URL, return_value=None),
         ):
             result = synthesize_why(target, tmp_path, llm)
 
@@ -263,7 +266,10 @@ class TestSynthesizeWhyNoHistory:
         target = Target(file=f)
         llm = MagicMock()
 
-        with patch(_PATCH_FILE_HISTORY, return_value=[]):
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=[]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
             result = synthesize_why(target, tmp_path, llm)
 
         assert result == "file has no git history"
@@ -288,6 +294,7 @@ class TestSynthesizeWhyLineTargetRouting:
             patch(_PATCH_EXTRACT_CODE, return_value="code"),
             patch(_PATCH_RESOLVE_RANGE, return_value=(5, 5)),
             patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
         ):
             synthesize_why(target, tmp_path, llm)
 
@@ -307,6 +314,7 @@ class TestSynthesizeWhyFileOnlyRouting:
         with (
             patch(_PATCH_FILE_HISTORY, return_value=[]) as mock_file_hist,
             patch(_PATCH_LINE_HISTORY) as mock_line_hist,
+            patch(_PATCH_GET_REPO_URL, return_value=None),
         ):
             synthesize_why(target, tmp_path, llm)
 
@@ -342,6 +350,7 @@ class TestSynthesizeWhyPRBodyWiring:
             patch(_PATCH_EXTRACT_CODE, return_value="code"),
             patch(_PATCH_RESOLVE_RANGE, return_value=None),
             patch(_PATCH_BUILD_PROMPT, side_effect=fake_build_prompt),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
         ):
             synthesize_why(target, tmp_path, llm, prs=prs)
 
@@ -378,6 +387,7 @@ class TestSynthesizeWhySymbolRouting:
             patch(_PATCH_EXTRACT_CODE, return_value="code"),
             patch(_PATCH_RESOLVE_RANGE, return_value=(2, 3)),
             patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
         ):
             synthesize_why(target, tmp_path, llm)
 
@@ -422,6 +432,7 @@ class TestSynthesizeWhyGitErrorHandling:
             patch(_PATCH_EXTRACT_CODE, return_value="code"),
             patch(_PATCH_RESOLVE_RANGE, return_value=None),
             patch(_PATCH_BUILD_PROMPT, side_effect=fake_build_prompt),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
         ):
             result = synthesize_why(target, tmp_path, llm)
 
@@ -476,6 +487,7 @@ class TestSynthesizeWhySparseHistoryOrdering:
             patch(_PATCH_EXTRACT_CODE, return_value="code"),
             patch(_PATCH_RESOLVE_RANGE, return_value=None),
             patch(_PATCH_BUILD_PROMPT, side_effect=fake_build_prompt),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
         ):
             synthesize_why(target, tmp_path, llm)
 
@@ -510,6 +522,7 @@ class TestSynthesizeWhySequencing:
                     "extract_code": "code",
                     "resolve_range": None,
                     "build_prompt": fake_messages,
+                    "get_repo_url": None,
                 }
                 return returns[name]
             return _side_effect
@@ -521,6 +534,7 @@ class TestSynthesizeWhySequencing:
             patch(_PATCH_EXTRACT_CODE, side_effect=track("extract_code")),
             patch(_PATCH_RESOLVE_RANGE, side_effect=track("resolve_range")),
             patch(_PATCH_BUILD_PROMPT, side_effect=track("build_prompt")),
+            patch(_PATCH_GET_REPO_URL, side_effect=track("get_repo_url")),
         ):
             synthesize_why(target, tmp_path, llm)
 
@@ -629,6 +643,7 @@ class TestSynthesizeWhyCitationLogging:
             patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
             patch(_PATCH_VALIDATE_CITATIONS, return_value=[fake_issue]) as mock_validate,
             patch(_PATCH_LOG) as mock_log,
+            patch(_PATCH_GET_REPO_URL, return_value=None),
         ):
             result = synthesize_why(target, tmp_path, llm)
 
@@ -669,6 +684,7 @@ class TestSynthesizeWhyCitationLogging:
             patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
             patch(_PATCH_VALIDATE_CITATIONS, return_value=[]) as mock_validate,
             patch(_PATCH_LOG) as mock_log,
+            patch(_PATCH_GET_REPO_URL, return_value=None),
         ):
             synthesize_why(target, tmp_path, llm)
 
@@ -705,6 +721,7 @@ class TestSynthesizeWhyStrictMode:
                 _PATCH_VALIDATE_CITATIONS,
                 side_effect=ValueError("citation validation failed: 1 issues"),
             ) as mock_validate,
+            patch(_PATCH_GET_REPO_URL, return_value=None),
             pytest.raises(ValueError, match="citation validation failed"),
         ):
             synthesize_why(target, tmp_path, llm, strict=True)


### PR DESCRIPTION
## Related Links
- Issue: https://github.com/tarungulati1988/why/issues/68
- Design: N/A (discussed in session)

## What
- Rewrites `WHY_SYSTEM_PROMPT` in `src/why/prompts.py` — principal engineer voice, city-evolution narrative structure, prose paragraphs instead of bullets, inline citations, natural hedging in place of a Confidence score section
- Adds `build_system_prompt(repo_url: str | None = None)` so the commit/PR link examples in the prompt use the actual repository URL rather than a hardcoded owner/repo
- Adds `_get_repo_url(repo)` to `synth.py` — resolves origin remote at synthesis time, converts SSH→HTTPS, strips `.git`, validates URL scheme and rejects control characters to prevent prompt injection
- Keeps `WHY_SYSTEM_PROMPT` as a backward-compatible alias pointing to the no-URL fallback form

## Why
- The old output read like a structured changelog — terse, bulleted, cold. A new engineer reading it got the *what* but not the *feel* of why decisions were made.
- Hardcoding `tarungulati1988/why` in the system prompt would produce wrong commit links for any other user running `why` against their own repo.
- The unsanitized remote URL was a prompt injection vector: a malicious `.git/config` could inject arbitrary text into the LLM system prompt.

## How
- `_SYSTEM_PROMPT_TEMPLATE` holds the prompt body with `{commit_link_example}` and `{pr_link_example}` as the only dynamic slots — `.format()` is used at call time, not at module load
- `build_system_prompt` restricts the real GitHub link format to `github.com` remotes only; non-GitHub remotes fall back to `<repo-url>` placeholder
- `_get_repo_url` uses `subprocess.run` with `timeout=5`, validates SSH URL structure (malformed no-`:` guard), checks scheme is `http`/`https`, and rejects `\n`/`\r`/`\x00` in the URL string
- Sparse-history notice wording updated: "Tag all findings [STRUCTURAL]" → "Describe these in natural prose as part of the narrative" to match the new system prompt tone

## Test Steps
- [ ] `uv run pytest tests/ -v` — 186 tests pass
- [ ] `why src/why/synth.py synthesize_why` — output reads as conversational prose, not a structured report
- [ ] Output includes inline commit links pointing at `https://github.com/tarungulati1988/why/commit/<sha>`
- [ ] No Confidence section in output; uncertainty expressed inline as natural language

## Other Notes
- `WHY_SYSTEM_PROMPT` kept as a module-level alias for backward compat; callers that import it directly still work but get the generic placeholder form (no repo URL)
- GitLab/Bitbucket remotes intentionally fall back to generic `<repo-url>` placeholder — GitHub-style `/commit/` and `/pull/` paths don't apply to other forges