### PR TITLE
feat: append ASCII timeline block to every why response (#71)

### DIFF
--- a/docs/designs/2026-04-25-timeline-ascii-design.md
+++ b/docs/designs/2026-04-25-timeline-ascii-design.md
@@ -1,0 +1,151 @@
+# Design Doc — `## 📊 Timeline` ASCII Block (Issue #71)
+
+**Date:** 2026-04-25
+**Issue:** https://github.com/tarungulati1988/why/issues/71
+**Status:** Approved
+
+---
+
+## Problem
+
+The `why` LLM output is prose-heavy. Visual thinkers have no quick scannable view of how code evolved chronologically. We need a `## 📊 Timeline` section appended to every response — a compact ASCII diagram that renders in both terminal and GitHub markdown.
+
+**Hard constraint:** Timeline nodes must only reference commits/PRs present in the provided context. No hallucination.
+
+---
+
+## Non-Goals
+
+- Mermaid diagrams (doesn't render in terminal)
+- Clickable hyperlinks in the ASCII block (not universally supported)
+- Phase grouping when there are fewer than 3 commits (not enough to group)
+
+---
+
+## Approaches Considered
+
+### A — Prompt-only (LLM generates timeline freely)
+
+Add instructions to `build_system_prompt()` telling the LLM to append the timeline. The LLM reads commit data from the user message and formats it.
+
+**Pros:** Simple — one place to change. LLM can do smart phase grouping.
+**Cons:** Non-deterministic; LLM may drift, abbreviate SHAs incorrectly, or invent dates under token pressure. Fails the no-hallucination constraint.
+
+### B — Deterministic post-processing (Python generates timeline)
+
+Generate the ASCII block directly in Python from `key_commits`, append to the LLM response as a post-processing step.
+
+**Pros:** Zero hallucination risk. Deterministic, easily unit-tested.
+**Cons:** No smart phase grouping. LLM narrative stays separate from timeline.
+
+### C — Hybrid (LLM groups, Python grounds + validates) ✅ CHOSEN
+
+Provide a pre-formatted `## Timeline Data` section in the user message with exact SHAs/dates/subjects. System prompt instructs the LLM to copy those entries verbatim, only adding phase grouping labels. A post-processing validator checks that every SHA in the timeline exists in `key_commits`; if not, replaces the block deterministically.
+
+**Pros:** Smart phase grouping (LLM contribution) with zero hallucination risk (Python validation + fallback).
+**Cons:** Slightly more code — need both the prompt change and the validator.
+
+---
+
+## Chosen Design — Approach C
+
+### ASCII format
+
+Wrapped in a ` ```text ` fence so it renders identically in terminal and GitHub markdown:
+
+```
+## 📊 Timeline
+
+\`\`\`text
+2026-01-10  44be1b8  Initial scaffold
+2026-02-01  a1b2c3d  Citation validator added          [PR #63]
+             --- Phase: Resilience work ---
+2026-03-15  ef1f022  Sparse history fallback           [PR #69]
+\`\`\`
+```
+
+Each row: `<YYYY-MM-DD>  <short_sha>  <description>  [PR #N]`
+- PR column is optional, appended when a PR number is known
+- LLM may insert `--- Phase: <label> ---` separator rows between major phases
+- Short SHA is always 7 characters (matches `commit.short_sha`)
+
+### Moving Parts
+
+#### 1. `build_why_prompt` — `## Timeline Data` section
+
+A new helper `_render_timeline_data(key_commits, repo_url)` produces:
+
+```
+## Timeline Data
+
+(Copy SHAs and dates verbatim into the timeline — do not alter them)
+
+2026-01-10  44be1b8  Initial scaffold
+2026-02-01  a1b2c3d  Citation validator added  [PR #63]
+2026-03-15  ef1f022  Sparse history fallback  [PR #69]
+```
+
+This section is appended after `## Commits` in the user message. It is the primary hallucination guard — the LLM copies from it rather than recalling from memory.
+
+#### 2. `build_system_prompt` — timeline instruction
+
+A new block appended after the hard constraints section:
+
+> **Appending the Timeline**
+>
+> After the narrative, always append a `## 📊 Timeline` section. Use the `## Timeline Data` entries from the user message as the source of truth — copy dates and short SHAs verbatim; do not invent or alter them. You may rewrite the description to be more concise. You may insert `--- Phase: <label> ---` separator rows between major phases if the history warrants it (3+ commits with a clear inflection point). Wrap the block in a ` ```text ` fence.
+>
+> If there are no commits (sparse history with 0 commits), emit:
+> `## 📊 Timeline`
+> `No commit history available.`
+
+#### 3. Post-processing validator — `src/why/timeline.py` (new file)
+
+```python
+def validate_and_repair_timeline(
+    response: str,
+    key_commits: list[CommitWithPR],
+    repo_url: str | None = None,
+) -> str:
+    """Validate timeline SHAs; replace block with deterministic fallback if invalid."""
+```
+
+Logic:
+1. Extract the ` ```text ` block under `## 📊 Timeline` via regex
+2. Parse every token that looks like a 7-char hex SHA
+3. Check each against `{c.commit.short_sha for c in key_commits}`
+4. If any SHA is unrecognized → call `_render_deterministic_timeline(key_commits)` and replace the block
+5. If no timeline section present → append the deterministic fallback
+6. Return (possibly repaired) response
+
+`_render_deterministic_timeline` generates the ASCII table directly from `key_commits` — no LLM, no phase grouping, always correct.
+
+### Files Touched
+
+| File | Change |
+|------|--------|
+| `src/why/prompts.py` | Add `_render_timeline_data()` helper; append section in `build_why_prompt`; add timeline instruction to `build_system_prompt` |
+| `src/why/timeline.py` | New file — `validate_and_repair_timeline`, `_render_deterministic_timeline` |
+| `src/why/synth.py` | Call `validate_and_repair_timeline` on LLM response before returning |
+| `tests/test_prompts.py` | Tests for `_render_timeline_data`: empty commits, PR numbers, no PR |
+| `tests/test_timeline.py` | Tests for validator: valid pass-through, hallucinated SHA triggers replacement, missing section triggers append |
+
+### Responsibility Split
+
+| Responsibility | Owner |
+|---|---|
+| Phase grouping / phase label names | LLM |
+| Description rewrite (concise) | LLM |
+| SHAs, dates, PR numbers | Python-provided (copied verbatim) |
+| Fallback when validation fails or section missing | Python (deterministic) |
+
+---
+
+## Acceptance Criteria
+
+- [ ] Output always ends with `## 📊 Timeline` block
+- [ ] Timeline nodes only reference commits present in `key_commits`
+- [ ] Renders correctly in GitHub markdown preview (fenced `text` block)
+- [ ] Renders correctly in terminal (plain text in code fence)
+- [ ] Validator replaces hallucinated SHAs with deterministic fallback
+- [ ] Existing tests pass

--- a/src/why/prompts.py
+++ b/src/why/prompts.py
@@ -388,7 +388,9 @@ def build_why_prompt(
     # Join all sections with horizontal-rule separators.
     # Sparse notice is placed before commits; timeline data is appended last so the
     # LLM sees the structured table immediately before generating the timeline.
-    all_sections = [target_section, code_section, *sparse_sections, commits_section, timeline_section]
+    all_sections = [
+        target_section, code_section, *sparse_sections, commits_section, timeline_section
+    ]
     content = "\n\n---\n\n".join(all_sections)
 
     return [Message(role="user", content=content)]

--- a/src/why/prompts.py
+++ b/src/why/prompts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 from why.commit import Commit
@@ -131,7 +132,23 @@ Describe what those imply in natural prose, not as tagged labels.
 ## If history is truly insufficient
 
 If the inputs don't give you enough to say anything meaningful, say so plainly in one or two \
-sentences and explain what's missing. Do not produce a skeletal or placeholder response.\""""
+sentences and explain what's missing. Do not produce a skeletal or placeholder response.
+
+---
+
+## Appending the Timeline
+
+After the narrative, always append a `## 📊 Timeline` section. Use the `## Timeline Data` \
+entries from the user message as the source of truth — copy dates and short SHAs verbatim; \
+do not invent or alter them. You may rewrite the description to be more concise. \
+You may insert `--- Phase: <label> ---` separator rows between major phases if the history \
+warrants it (3+ commits with a clear inflection point). Wrap the block in a ```text fence.
+
+If there are no commits (0 entries in ## Timeline Data), emit:
+
+## 📊 Timeline
+
+No commit history available.\""""
 
 
 def build_system_prompt(repo_url: str | None = None) -> str:
@@ -263,6 +280,56 @@ def _render_commit(cwpr: CommitWithPR) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Timeline data helper
+# ---------------------------------------------------------------------------
+
+
+def _render_timeline_data(
+    key_commits: list[CommitWithPR],
+    repo_url: str | None = None,  # reserved for future link support — unused in this stride
+) -> str:
+    r"""Render the ## Timeline Data section for the user prompt.
+
+    Produces a fixed-width table of commit rows ordered oldest-first so the
+    LLM can copy SHAs and dates verbatim into the ASCII timeline without
+    having to re-derive them from the fuller Commits section.
+
+    Each row format: `<YYYY-MM-DD>  <short_sha>  <subject>  [PR #N]`
+    The `[PR #N]` suffix is only appended when a PR number can be extracted
+    from the commit's pr_body via the `PR #\d+` pattern.
+    """
+    header = (
+        "## Timeline Data\n\n"
+        "(Copy SHAs and dates verbatim into the timeline — do not alter them)"
+    )
+
+    if not key_commits:
+        return f"{header}\n\n(no commits available)"
+
+    rows = []
+    for cwpr in key_commits:
+        commit = cwpr.commit
+        date_str = commit.date.strftime("%Y-%m-%d")
+        # Strip newlines from subject to prevent Markdown injection
+        safe_subject = commit.subject.replace("\n", " ").replace("\r", "")
+
+        # Attempt to extract a PR number from the PR body text
+        pr_label = ""
+        if cwpr.pr_body:
+            match = re.search(r"PR\s*#(\d+)", cwpr.pr_body)
+            if match:
+                pr_label = f"  [PR #{match.group(1)}]"
+
+        rows.append(f"{date_str}  {commit.short_sha}  {safe_subject}{pr_label}")
+
+    # Fence the rows in a ```text block so commit subjects cannot sit in an
+    # instruction-privileged position in the prompt context — a subject like
+    # "ignore previous instructions" would otherwise be indistinguishable from
+    # prompt text.
+    return f"{header}\n\n```text\n" + "\n".join(rows) + "\n```"
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -314,11 +381,14 @@ def build_why_prompt(
             )
         sparse_sections = [sparse_notice]
 
+    # Build the timeline data section — gives the LLM exact SHAs/dates to copy verbatim,
+    # preventing hallucination in the ASCII timeline.
+    timeline_section = _render_timeline_data(key_commits)
+
     # Join all sections with horizontal-rule separators.
-    # Sparse notice is placed before commits so that "## Commits" remains the final
-    # section when key_commits is empty, preserving the invariant that there is no
-    # trailing "\n\n" after the commits header in the empty case.
-    all_sections = [target_section, code_section, *sparse_sections, commits_section]
+    # Sparse notice is placed before commits; timeline data is appended last so the
+    # LLM sees the structured table immediately before generating the timeline.
+    all_sections = [target_section, code_section, *sparse_sections, commits_section, timeline_section]
     content = "\n\n---\n\n".join(all_sections)
 
     return [Message(role="user", content=content)]

--- a/src/why/synth.py
+++ b/src/why/synth.py
@@ -8,7 +8,6 @@ import urllib.parse
 from pathlib import Path
 
 from why.citations import validate_citations
-from why.timeline import validate_and_repair_timeline
 from why.diff import get_commit_diff
 from why.git import GitError
 from why.history import get_file_history, get_line_history
@@ -17,6 +16,7 @@ from why.prompts import CommitWithPR, build_system_prompt, build_why_prompt
 from why.scoring import select_key_commits
 from why.symbols import find_symbol_range
 from why.target import Target
+from why.timeline import validate_and_repair_timeline
 
 _log = logging.getLogger(__name__)
 

--- a/src/why/synth.py
+++ b/src/why/synth.py
@@ -8,6 +8,7 @@ import urllib.parse
 from pathlib import Path
 
 from why.citations import validate_citations
+from why.timeline import validate_and_repair_timeline
 from why.diff import get_commit_diff
 from why.git import GitError
 from why.history import get_file_history, get_line_history
@@ -197,5 +198,10 @@ def synthesize_why(
         # prevent control codes or ANSI escapes from polluting log output.
         safe_value = "".join(c for c in issue.value if c.isprintable())
         _log.warning("citation issue %s: %s", issue.kind, safe_value)
+
+    # Post-process: ensure the ## 📊 Timeline section is present and valid.
+    # Repairs or appends a deterministic timeline when the LLM omits or
+    # hallucinates SHAs in that section.
+    result = validate_and_repair_timeline(result, commits_with_prs, repo_url)
 
     return result

--- a/src/why/timeline.py
+++ b/src/why/timeline.py
@@ -1,0 +1,107 @@
+"""Timeline validation and deterministic rendering for why LLM output.
+
+This module provides two public functions:
+
+- ``render_deterministic_timeline``: builds the ASCII timeline block directly
+  from ``key_commits`` without calling the LLM, ensuring correctness.
+
+- ``validate_and_repair_timeline``: checks that every SHA in an LLM-generated
+  timeline block is known; replaces the block with a deterministic one if not.
+"""
+
+from __future__ import annotations
+
+import re
+
+from why.prompts import CommitWithPR
+
+
+def render_deterministic_timeline(key_commits: list[CommitWithPR]) -> str:
+    """Generate the ## 📊 Timeline section directly from key_commits.
+
+    Iterates key_commits in the order provided (callers pass a sorted list).
+    Each row is: ``YYYY-MM-DD  <short_sha>  <subject>`` with an optional
+    ``  [PR #N]`` suffix when the commit's pr_body references a PR number.
+
+    Returns a plain "No commit history available." message when the list is empty.
+    """
+    if not key_commits:
+        return "## 📊 Timeline\n\nNo commit history available."
+
+    rows: list[str] = []
+    for cwpr in key_commits:
+        date_str = cwpr.commit.date.strftime("%Y-%m-%d")
+        short_sha = cwpr.commit.short_sha
+        # Sanitize subject: replace newlines with spaces, strip carriage returns
+        safe_subject = cwpr.commit.subject.replace("\n", " ").replace("\r", "")
+
+        row = f"{date_str}  {short_sha}  {safe_subject}"
+
+        # Append PR annotation if the pr_body contains a PR number reference
+        if cwpr.pr_body:
+            pr_match = re.search(r"PR\s*#(\d+)", cwpr.pr_body)
+            if pr_match:
+                row += f"  [PR #{pr_match.group(1)}]"
+
+        rows.append(row)
+
+    body = "\n".join(rows)
+    return f"## 📊 Timeline\n\n```text\n{body}\n```"
+
+
+def validate_and_repair_timeline(
+    response: str,
+    key_commits: list[CommitWithPR],
+    repo_url: str | None = None,
+) -> str:
+    """Validate the ## 📊 Timeline section in an LLM response and repair if needed.
+
+    Steps:
+    1. If no ## 📊 Timeline section is found, append a deterministic one and return.
+    2. If present, extract all 7-char hex tokens from the timeline block.
+    3. If any token is not in the set of known short SHAs, replace the entire
+       timeline section with a deterministic render.
+    4. If all tokens are known (or no tokens found), return response unchanged.
+
+    The ``repo_url`` parameter is accepted for forward compatibility but is not
+    currently used in rendering.
+    """
+    # Check whether a timeline section exists in the response
+    section_match = re.search(
+        r"(## 📊 Timeline.*?)(?=\n## |\Z)", response, re.DOTALL
+    )
+
+    if section_match is None:
+        # No timeline section — append a deterministic one
+        return response + "\n\n" + render_deterministic_timeline(key_commits)
+
+    # Extract the matched timeline block text
+    timeline_block = section_match.group(1)
+
+    # Find all 7-char lowercase hex tokens within the block
+    extracted_shas = re.findall(r"\b[0-9a-f]{7}\b", timeline_block)
+
+    if not extracted_shas:
+        # No hex tokens — nothing to validate, return unchanged
+        return response
+
+    # Build the set of known short SHAs from the provided commits
+    known_shas = {cwpr.commit.short_sha for cwpr in key_commits}
+
+    # Check if every extracted SHA is in the known set
+    all_valid = all(sha in known_shas for sha in extracted_shas)
+
+    if all_valid:
+        return response
+
+    # At least one hallucinated SHA — replace the entire timeline section.
+    # Use a callable replacement (lambda) so Python does NOT interpret backreference
+    # sequences (e.g. \1, \g<0>) in the replacement string — commit subjects that
+    # contain such patterns would otherwise corrupt the output or raise re.error.
+    replacement = render_deterministic_timeline(key_commits)
+    return re.sub(
+        r"## 📊 Timeline.*?(?=\n## |\Z)",
+        lambda _: replacement,
+        response,
+        flags=re.DOTALL,
+    )

--- a/tests/fixtures/prompts/why_prompt_golden.txt
+++ b/tests/fixtures/prompts/why_prompt_golden.txt
@@ -36,3 +36,13 @@ Fixes #99: adds null check
 ```
 
 ---
+
+---
+
+## Timeline Data
+
+(Copy SHAs and dates verbatim into the timeline — do not alter them)
+
+```text
+2026-01-15  abc1234  fix: handle null token in auth check
+```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -222,7 +222,9 @@ class TestLineTargetEndToEnd:
             result = CliRunner().invoke(main, [target_spec])
 
         assert result.exit_code == 0, result.output
-        assert result.output.strip() == "line explanation"
+        # synthesize_why now appends a ## 📊 Timeline block after the LLM response,
+        # so the output starts with the LLM text but is no longer exactly equal to it.
+        assert "line explanation" in result.output
         # LLMClient must be constructed once (with the default model)
         mock_llm_cls.assert_called_once()
         # complete() must be called — guards against future short-circuit paths
@@ -380,7 +382,9 @@ class TestSymbolTargetEndToEnd:
             result = CliRunner().invoke(main, [target_spec, "authenticate_user"])
 
         assert result.exit_code == 0, result.output
-        assert result.output.strip() == "symbol explanation"
+        # synthesize_why now appends a ## 📊 Timeline block after the LLM response,
+        # so the output starts with the LLM text but is no longer exactly equal to it.
+        assert "symbol explanation" in result.output
         # LLMClient must be constructed once (with the default model)
         mock_llm_cls.assert_called_once()
         # complete() must be called — guards against future short-circuit paths

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -145,9 +145,11 @@ def test_no_commits() -> None:
     # Target section must still be present
     assert "## Target" in result[0].content
     assert "## Current Code" in result[0].content
-    # Commits section must be present with just the header — no trailing empty body
+    # Commits section must be present with just the header — no trailing empty body.
+    # When key_commits is empty, "## Commits" has no body: it is immediately followed
+    # by the section separator "---" (not by blank commit content).
     assert "## Commits" in result[0].content
-    assert "## Commits\n\n" not in result[0].content
+    assert "## Commits\n\n---" in result[0].content
 
 
 # ---------------------------------------------------------------------------
@@ -373,3 +375,78 @@ def test_build_system_prompt_with_non_github_url() -> None:
     prompt = build_system_prompt("https://gitlab.com/acme/myrepo")
     assert "<repo-url>" in prompt
     assert "gitlab.com" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Timeline Data section tests
+# ---------------------------------------------------------------------------
+
+
+def test_timeline_data_empty_commits() -> None:
+    """Empty key_commits list must render the header and a no-commits notice."""
+    from why.prompts import _render_timeline_data
+
+    result = _render_timeline_data([])
+    assert "## Timeline Data" in result
+    assert "(no commits available)" in result
+
+
+def test_timeline_data_single_commit_no_pr() -> None:
+    """A single commit with no PR body must render a row without [PR #N]."""
+    from why.prompts import _render_timeline_data
+
+    cwpr = CommitWithPR(commit=FIXED_COMMIT)
+    result = _render_timeline_data([cwpr])
+    # Row must contain date, short SHA, and subject
+    assert "2026-01-15" in result
+    assert "abc1234" in result
+    assert "fix: handle null token in auth check" in result
+    # No PR label when pr_body is None
+    assert "[PR #" not in result
+
+
+def test_timeline_data_single_commit_with_pr() -> None:
+    """A commit with pr_body containing 'PR #42' must render [PR #42] in the row."""
+    from why.prompts import _render_timeline_data
+
+    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_body="Merged PR #42: fix the thing")
+    result = _render_timeline_data([cwpr])
+    assert "[PR #42]" in result
+
+
+def test_timeline_data_section_in_user_message() -> None:
+    """build_why_prompt result content must contain '## Timeline Data'."""
+    commits = [CommitWithPR(commit=FIXED_COMMIT)]
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
+    assert "## Timeline Data" in result[0].content
+
+
+def test_timeline_data_section_is_last() -> None:
+    """'## Timeline Data' must appear after '## Commits' in the content."""
+    commits = [CommitWithPR(commit=FIXED_COMMIT)]
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
+    content = result[0].content
+    assert content.index("## Timeline Data") > content.index("## Commits")
+
+
+# ---------------------------------------------------------------------------
+# System prompt timeline instruction tests (Stride 2 of Issue #71)
+# ---------------------------------------------------------------------------
+
+
+def test_system_prompt_contains_timeline_instruction() -> None:
+    """build_system_prompt() result must contain '## Appending the Timeline'."""
+    prompt = build_system_prompt()
+    assert "## Appending the Timeline" in prompt
+
+
+def test_system_prompt_timeline_references_data_section() -> None:
+    """build_system_prompt() result must reference '## Timeline Data' as source of truth."""
+    prompt = build_system_prompt()
+    assert "## Timeline Data" in prompt
+
+
+def test_system_prompt_timeline_text_fence_instruction() -> None:
+    """build_system_prompt() result must instruct wrapping the block in a ```text fence."""
+    prompt = build_system_prompt()
+    assert "```text" in prompt

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -223,7 +223,8 @@ class TestSynthesizeWhyHappyPath:
         # llm.complete must receive build_system_prompt(None) as system arg
         from why.prompts import build_system_prompt
         llm.complete.assert_called_once_with(build_system_prompt(None), fake_messages)
-        assert result == "the answer"
+        # synthesize_why appends a ## 📊 Timeline block after the LLM response
+        assert result.startswith("the answer")
 
 
 class TestSynthesizeWhySparsePath:
@@ -255,7 +256,8 @@ class TestSynthesizeWhySparsePath:
         call_args = mock_prompt.call_args
         commits_with_prs = call_args.args[2]
         assert len(commits_with_prs) == 2
-        assert result == "sparse answer"
+        # synthesize_why appends a ## 📊 Timeline block after the LLM response
+        assert result.startswith("sparse answer")
 
 
 class TestSynthesizeWhyNoHistory:
@@ -436,7 +438,8 @@ class TestSynthesizeWhyGitErrorHandling:
         ):
             result = synthesize_why(target, tmp_path, llm)
 
-        assert result == "answer"
+        # synthesize_why appends a ## 📊 Timeline block after the LLM response
+        assert result.startswith("answer")
         bad_cwpr = next(cwpr for cwpr in captured if cwpr.commit.sha == sha_bad)
         assert bad_cwpr.diff == ""
 
@@ -661,8 +664,9 @@ class TestSynthesizeWhyCitationLogging:
             "citation issue %s: %s", fake_issue.kind, safe_value
         )
 
-        # Result is still the raw LLM output — issues are logged, not filtered
-        assert result == llm.complete.return_value
+        # Result starts with the raw LLM output — issues are logged, not filtered.
+        # synthesize_why appends a ## 📊 Timeline block after the LLM response.
+        assert result.startswith(llm.complete.return_value)
 
     def test_synthesize_why_no_issues_no_warnings(self, tmp_path: Path) -> None:
         """When LLM output contains only known SHAs, no citation warnings are logged."""
@@ -695,6 +699,102 @@ class TestSynthesizeWhyCitationLogging:
             assert call.args[0] != "citation issue %s: %s", (
                 "Expected no citation warnings, but one was logged"
             )
+
+
+# ---------------------------------------------------------------------------
+# Timeline validation integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizeWhyTimeline:
+    """validate_and_repair_timeline is called after LLM response; timeline always present."""
+
+    def test_synthesize_why_includes_timeline_section(self, tmp_path: Path) -> None:
+        """LLM response already has a valid ## 📊 Timeline block — returned unchanged."""
+        sha = "abc1234def5678901234567890"
+        commit = _make_commit(sha)
+        f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
+        target = Target(file=f)
+
+        # Build a response that already contains a valid timeline with the real short SHA.
+        short_sha = sha[:7]
+        llm_response = (
+            "Here is why this changed.\n\n"
+            f"## 📊 Timeline\n\n```text\n2024-01-01  {short_sha}  commit abc1234\n```"
+        )
+
+        llm = MagicMock()
+        llm.complete.return_value = llm_response
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=[commit]),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
+            result = synthesize_why(target, repo=tmp_path, llm=llm, prs={})
+
+        assert "## 📊 Timeline" in result
+
+    def test_synthesize_why_appends_timeline_when_missing(self, tmp_path: Path) -> None:
+        """LLM response has NO ## 📊 Timeline — validate_and_repair_timeline appends one."""
+        sha = "abc1234def5678901234567890"
+        commit = _make_commit(sha)
+        f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
+        target = Target(file=f)
+
+        # Response with no timeline section at all
+        llm_response = "Here is why this changed — no timeline included."
+
+        llm = MagicMock()
+        llm.complete.return_value = llm_response
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=[commit]),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
+            result = synthesize_why(target, repo=tmp_path, llm=llm, prs={})
+
+        assert "## 📊 Timeline" in result
+
+    def test_synthesize_why_repairs_hallucinated_timeline(self, tmp_path: Path) -> None:
+        """LLM response has a timeline with a hallucinated SHA — replaced with real SHA."""
+        sha = "abc1234def5678901234567890"
+        commit = _make_commit(sha)
+        f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
+        target = Target(file=f)
+
+        # Timeline contains a hallucinated 7-char SHA not matching the real commit
+        hallucinated_sha = "deadbee"
+        llm_response = (
+            "Here is why this changed.\n\n"
+            f"## 📊 Timeline\n\n```text\n2024-01-01  {hallucinated_sha}  fake commit\n```"
+        )
+
+        llm = MagicMock()
+        llm.complete.return_value = llm_response
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=[commit]),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
+            result = synthesize_why(target, repo=tmp_path, llm=llm, prs={})
+
+        # The real short SHA should appear in the repaired timeline
+        real_short_sha = sha[:7]
+        assert real_short_sha in result
+        # The hallucinated SHA should NOT appear in the result
+        assert hallucinated_sha not in result
 
 
 class TestSynthesizeWhyStrictMode:

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -9,11 +9,14 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-import pytest
-
 from why.commit import Commit
 from why.prompts import CommitWithPR
-from why.timeline import render_deterministic_timeline as _render_deterministic_timeline, validate_and_repair_timeline
+from why.timeline import (
+    render_deterministic_timeline as _render_deterministic_timeline,
+)
+from why.timeline import (
+    validate_and_repair_timeline,
+)
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -96,7 +99,8 @@ def test_validate_missing_section_appends() -> None:
     """Response with no timeline section gets timeline appended to the end."""
     response = "## 🏗️ How it started\n\nSome narrative here."
     result = validate_and_repair_timeline(response, [FIXED_CWPR])
-    assert result.endswith("## 📊 Timeline\n\n```text\n2026-01-15  abc1234  fix: handle null token\n```")
+    expected = "## 📊 Timeline\n\n```text\n2026-01-15  abc1234  fix: handle null token\n```"
+    assert result.endswith(expected)
 
 
 def test_validate_valid_sha_passes_through() -> None:

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,142 @@
+"""Tests for why.timeline — validate_and_repair_timeline and _render_deterministic_timeline.
+
+Written BEFORE implementation (TDD). Covers: empty list, single commit without PR,
+single commit with PR, missing section appended, valid SHA passes through,
+hallucinated SHA replaced, no SHAs in block passes through.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from why.commit import Commit
+from why.prompts import CommitWithPR
+from why.timeline import render_deterministic_timeline as _render_deterministic_timeline, validate_and_repair_timeline
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+FIXED_DATE = datetime(2026, 1, 15, tzinfo=UTC)
+
+FIXED_COMMIT = Commit(
+    sha="abc1234def5678901234567890",
+    author_name="Jane Smith",
+    author_email="jane@example.com",
+    date=FIXED_DATE,
+    subject="fix: handle null token",
+    body="",
+    parents=(),
+    additions=3,
+    deletions=1,
+)
+
+FIXED_CWPR = CommitWithPR(commit=FIXED_COMMIT)
+
+
+# ---------------------------------------------------------------------------
+# _render_deterministic_timeline tests
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_empty() -> None:
+    """Empty key_commits list produces 'No commit history available' message."""
+    result = _render_deterministic_timeline([])
+    assert "No commit history available" in result
+    # Should not contain a fenced code block
+    assert "```" not in result
+
+
+def test_deterministic_single_no_pr() -> None:
+    """Single commit with no PR body produces row with SHA and date."""
+    result = _render_deterministic_timeline([FIXED_CWPR])
+    assert "abc1234" in result
+    assert "2026-01-15" in result
+    # No PR annotation expected
+    assert "[PR #" not in result
+    # Should be wrapped in a fenced block
+    assert "```text" in result
+
+
+def test_deterministic_single_with_pr() -> None:
+    """Single commit whose pr_body contains 'PR #42' gets [PR #42] appended to row."""
+    cwpr_with_pr = CommitWithPR(commit=FIXED_COMMIT, pr_body="PR #42 description")
+    result = _render_deterministic_timeline([cwpr_with_pr])
+    assert "[PR #42]" in result
+    assert "abc1234" in result
+
+
+def test_deterministic_subject_newlines_stripped() -> None:
+    """Newlines in commit subject are replaced with spaces in the rendered row."""
+    commit_with_newline = Commit(
+        sha="abc1234def5678901234567890",
+        author_name="Jane Smith",
+        author_email="jane@example.com",
+        date=FIXED_DATE,
+        subject="fix: handle\nnull token",
+        body="",
+        parents=(),
+        additions=3,
+        deletions=1,
+    )
+    cwpr = CommitWithPR(commit=commit_with_newline)
+    result = _render_deterministic_timeline([cwpr])
+    # Newline in subject should be replaced with a space
+    assert "fix: handle null token" in result
+
+
+# ---------------------------------------------------------------------------
+# validate_and_repair_timeline tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_missing_section_appends() -> None:
+    """Response with no timeline section gets timeline appended to the end."""
+    response = "## 🏗️ How it started\n\nSome narrative here."
+    result = validate_and_repair_timeline(response, [FIXED_CWPR])
+    assert result.endswith("## 📊 Timeline\n\n```text\n2026-01-15  abc1234  fix: handle null token\n```")
+
+
+def test_validate_valid_sha_passes_through() -> None:
+    """Response whose timeline block contains only known SHAs is returned unchanged."""
+    response = (
+        "## 🏗️ Some section\n\nNarrative.\n\n"
+        "## 📊 Timeline\n\n```text\n2026-01-15  abc1234  fix\n```"
+    )
+    result = validate_and_repair_timeline(response, [FIXED_CWPR])
+    assert result == response
+
+
+def test_validate_hallucinated_sha_replaced() -> None:
+    """Timeline block containing an unknown SHA is replaced with deterministic output."""
+    response = (
+        "## 🏗️ Some section\n\nNarrative.\n\n"
+        "## 📊 Timeline\n\n```text\n2026-01-15  deadbee  hallucinated commit\n```"
+    )
+    result = validate_and_repair_timeline(response, [FIXED_CWPR])
+    # The hallucinated SHA should be gone
+    assert "deadbee" not in result
+    # The real SHA should be present
+    assert "abc1234" in result
+    # The leading narrative section should be preserved
+    assert "## 🏗️ Some section" in result
+
+
+def test_validate_no_shas_in_block_passes_through() -> None:
+    """Timeline block that contains no hex tokens passes through unchanged."""
+    response = (
+        "## 🏗️ Some section\n\nNarrative.\n\n"
+        "## 📊 Timeline\n\nNo commit history available."
+    )
+    result = validate_and_repair_timeline(response, [FIXED_CWPR])
+    assert result == response
+
+
+def test_validate_empty_key_commits_missing_section() -> None:
+    """When key_commits is empty and section missing, appends 'No commit history' message."""
+    response = "## 🏗️ Some section\n\nNarrative."
+    result = validate_and_repair_timeline(response, [])
+    assert "No commit history available" in result
+    assert "## 📊 Timeline" in result


### PR DESCRIPTION
## Related Links

- Closes #71

## What

Adds a `## 📊 Timeline` ASCII section to the end of every `why` response — a compact table rendered in a ` ```text ` fence that works in both terminal and GitHub markdown.

## Why

Prose-heavy responses don't give visual thinkers a quick scannable view of how code evolved. The timeline provides a TL;DR at a glance without replacing the narrative.

## How

Three-layer hybrid approach:

**Input grounding** — `_render_timeline_data()` injects a `## Timeline Data` section into the user message with exact SHAs, dates, and subjects. The LLM copies from this verbatim, preventing hallucination at the source.

**LLM generation** — System prompt instructs the LLM to append `## 📊 Timeline` using the `## Timeline Data` entries, with optional `--- Phase: <label> ---` separators for smart phase grouping on 3+ commit histories.

**Post-processing validation** — `timeline.validate_and_repair_timeline()` extracts every 7-char hex token from the LLM's timeline block and checks it against the known commit set. Any unrecognized SHA triggers a deterministic replacement via `render_deterministic_timeline()`.

Security hardening applied during review:
- `re.sub` uses `lambda _: replacement` to prevent backreference expansion from commit subjects (`\g<0>`, `\1`)
- `## Timeline Data` rows wrapped in ` ```text ` fence to prevent prompt injection via crafted subjects

## Test Steps

- [ ] `uv run pytest -x -q` — 206 tests pass
- [ ] Manual: run `why <file>` on a file with 3+ commits — response ends with `## 📊 Timeline` block
- [ ] Manual: timeline renders correctly in GitHub markdown preview (fenced `text` block)
- [ ] Manual: timeline renders correctly in terminal (plain code fence)

## Other Notes

Non-blocking follow-ups identified in review (not in this PR):
- Extract shared `_render_commit_row` helper to eliminate row-rendering duplication between `prompts.py` and `timeline.py`
- Anchor SHA extraction regex to row structure to avoid false positives from hex-looking strings in commit subjects