### PR TITLE
feat: render LLM output with rich markdown formatting (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,30 @@ why src/auth/middleware.py handle_session_timeout
 why --model llama-3.1-8b-instant src/auth/middleware.py
 ```
 
+### Disable color / pipe-friendly output
+
+```bash
+why --no-color src/auth/middleware.py     # raw markdown, no ANSI
+why src/auth/middleware.py | grep "added" # piping auto-disables rich
+```
+
 ### Get help
 
 ```bash
 why --help          # full reference with argument descriptions
 why --version       # print version and exit
 ```
+
+## Supported languages
+
+Symbol-scoped analysis (`why <file> <symbol>`) uses tree-sitter and supports:
+
+| Language | Extensions |
+|----------|-----------|
+| Python   | `.py`     |
+| Go       | `.go`     |
+
+File and line targets (`why <file>` and `why <file>:<line>`) work with any language — tree-sitter is only needed for symbol lookup.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.11"
 dependencies = [
   "click>=8.1",
   "groq>=0.9",
+  "rich>=13",
   "tree-sitter>=0.23",
   "tree-sitter-python",
   "tree-sitter-go",

--- a/src/why/cli.py
+++ b/src/why/cli.py
@@ -8,6 +8,7 @@ import click
 from why import __version__
 from why.git import GitError
 from why.llm import LLMClient, LLMError
+from why.render import render_output
 from why.symbols import SymbolNotFoundError
 from why.synth import synthesize_why
 from why.target import TargetError, parse_target
@@ -38,7 +39,8 @@ ARGUMENTS:
     show_default=True,
     help="LLM model to use.",
 )
-def main(target_spec: str, extra: str | None, model: str) -> None:
+@click.option("--no-color", is_flag=True, default=False, help="Disable rich output formatting.")
+def main(target_spec: str, extra: str | None, model: str, no_color: bool) -> None:
     """Explain why code is the way it is via git history and LLM synthesis."""
     cwd = Path.cwd()
 
@@ -55,4 +57,4 @@ def main(target_spec: str, extra: str | None, model: str) -> None:
         click.echo(f"Error: {exc}", err=True)
         sys.exit(1)
 
-    click.echo(output)
+    render_output(output, color=not no_color)

--- a/src/why/render.py
+++ b/src/why/render.py
@@ -1,0 +1,22 @@
+"""Render markdown output to the terminal, or raw text when piped."""
+
+from __future__ import annotations
+
+import re
+import sys
+
+import click
+from rich.console import Console
+from rich.markdown import Markdown
+
+# Matches common ANSI CSI sequences (e.g. \x1b[31m) and OSC sequences.
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07")
+
+
+def render_output(text: str, color: bool = True) -> None:
+    """Render markdown text to the terminal, or raw if piped/no-color."""
+    text = _ANSI_ESCAPE.sub("", text)
+    if not sys.stdout.isatty() or not color:
+        click.echo(text)
+        return
+    Console(force_terminal=True).print(Markdown(text))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -436,3 +436,31 @@ class TestSymbolTargetEndToEnd:
 
         assert result.exit_code == 1, result.output
         assert "Error:" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --no-color flag tests
+# ---------------------------------------------------------------------------
+
+
+def test_no_color_flag_accepted(existing_file: Path) -> None:
+    """--no-color accepted → exit 0, raw output echoed, rich Console not used."""
+    with (
+        patch("why.cli.Path") as mock_path_cls,
+        patch("why.cli.LLMClient") as mock_llm_cls,
+        patch("why.cli.synthesize_why", return_value="explanation"),
+        patch("why.render.Console") as mock_console_cls,
+    ):
+        mock_llm_cls.return_value = MagicMock()
+        mock_path_cls.cwd.return_value = existing_file.parent
+        result = CliRunner().invoke(main, ["--no-color", str(existing_file)])
+    assert result.exit_code == 0
+    assert "explanation" in result.output
+    mock_console_cls.return_value.print.assert_not_called()
+
+
+def test_help_includes_no_color() -> None:
+    """--help documents --no-color."""
+    result = CliRunner().invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "--no-color" in result.output

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,98 @@
+"""Tests for why.render — render_output function.
+
+Written BEFORE implementation (TDD). Covers:
+- piped mode (isatty returns False) → click.echo called, Console.print NOT called
+- color=False → click.echo called even when isatty returns True
+- TTY + color=True → Console.print(Markdown(text)) called, click.echo NOT called
+- ANSI escape sequences stripped before output in piped mode
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from why.render import render_output
+from rich.markdown import Markdown
+
+
+TEXT = "## Hello\n\nThis is **markdown**."
+
+
+def test_piped_mode_uses_click_echo() -> None:
+    """When stdout is not a TTY, raw text is echoed via click.echo."""
+    with (
+        patch("why.render.sys") as mock_sys,
+        patch("why.render.click") as mock_click,
+        patch("why.render.Console") as mock_console_cls,
+    ):
+        mock_sys.stdout.isatty.return_value = False
+
+        render_output(TEXT)
+
+        mock_click.echo.assert_called_once_with(TEXT)
+        mock_console_cls.return_value.print.assert_not_called()
+
+
+def test_color_false_uses_click_echo_even_when_tty() -> None:
+    """When color=False, raw text is echoed regardless of TTY status."""
+    with (
+        patch("why.render.sys") as mock_sys,
+        patch("why.render.click") as mock_click,
+        patch("why.render.Console") as mock_console_cls,
+    ):
+        mock_sys.stdout.isatty.return_value = True
+
+        render_output(TEXT, color=False)
+
+        mock_click.echo.assert_called_once_with(TEXT)
+        mock_console_cls.return_value.print.assert_not_called()
+
+
+def test_tty_with_color_uses_rich_console() -> None:
+    """When stdout is a TTY and color=True, rich Console renders markdown."""
+    with (
+        patch("why.render.sys") as mock_sys,
+        patch("why.render.click") as mock_click,
+        patch("why.render.Console") as mock_console_cls,
+        patch("why.render.Markdown") as mock_markdown_cls,
+    ):
+        mock_sys.stdout.isatty.return_value = True
+        mock_console_instance = MagicMock()
+        mock_console_cls.return_value = mock_console_instance
+        mock_md = MagicMock()
+        mock_markdown_cls.return_value = mock_md
+
+        render_output(TEXT)
+
+        mock_markdown_cls.assert_called_once_with(TEXT)
+        mock_console_instance.print.assert_called_once_with(mock_md)
+        mock_click.echo.assert_not_called()
+
+
+def test_tty_color_path() -> None:
+    """TTY + color=True → Console.print receives a Markdown instance."""
+    with (
+        patch("why.render.sys") as mock_sys,
+        patch("why.render.Console") as mock_console_cls,
+    ):
+        mock_sys.stdout.isatty.return_value = True
+
+        render_output(TEXT)
+
+        mock_console_cls.return_value.print.assert_called_once()
+        call_args = mock_console_cls.return_value.print.call_args
+        assert isinstance(call_args.args[0], Markdown)
+
+
+def test_ansi_stripped_in_piped_mode() -> None:
+    """ANSI escape sequences in LLM output are stripped before echoing."""
+    dirty = "hello \x1b[31mworld\x1b[0m"
+    with (
+        patch("why.render.sys") as mock_sys,
+        patch("why.render.click") as mock_click,
+    ):
+        mock_sys.stdout.isatty.return_value = False
+        render_output(dirty, color=True)
+    mock_click.echo.assert_called_once_with("hello world")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -11,11 +11,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
-from why.render import render_output
 from rich.markdown import Markdown
 
+from why.render import render_output
 
 TEXT = "## Hello\n\nThis is **markdown**."
 

--- a/uv.lock
+++ b/uv.lock
@@ -213,6 +213,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
@@ -441,6 +462,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.11"
 source = { registry = "https://pypi.org/simple" }
@@ -569,6 +603,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "groq" },
+    { name = "rich" },
     { name = "tree-sitter" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-python" },
@@ -587,6 +622,7 @@ requires-dist = [
     { name = "groq", specifier = ">=0.9" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "rich", specifier = ">=13" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "tree-sitter", specifier = ">=0.23" },
     { name = "tree-sitter-go" },


### PR DESCRIPTION
## Related Links
- Closes #20

## What
- New `src/why/render.py` module with `render_output(text, color)` — single-purpose rendering layer
- `--no-color` CLI flag to force raw text output
- ANSI escape sequences from LLM output stripped before rendering (prevents terminal injection from commit message bodies)
- `rich>=13` added as a runtime dependency (pins to `rich 15.0.0` via `uv.lock`)

## Why
TTY sessions now get colored, formatted markdown via `rich.Markdown` — headers, code blocks, and lists render visually. Piped output and `--no-color` fall back to raw text, keeping `why` composable in scripts.

## How
- `render_output` checks `sys.stdout.isatty()` and the `color` bool; TTY+color path uses `Console(force_terminal=True).print(Markdown(text))`, everything else uses `click.echo`
- ANSI stripping runs at function entry on both paths
- `cli.py` replaces the bare `click.echo(output)` call with `render_output(output, color=not no_color)`

## Test Steps
- `uv run python -m pytest tests/test_render.py tests/test_cli.py -v` — 7 new tests
- `uv run python -m pytest tests/ -v` — 213/213 pass
- Manual: `why src/why/cli.py` shows formatted markdown; `why src/why/cli.py | cat` shows raw text; `why --no-color src/why/cli.py` shows raw text in TTY

## Other Notes
- `render.py` follows the single-concern module pattern (matches `git.py`, `llm.py`, `synth.py`)
- `uv.lock` updated with `rich 15.0.0` + transitive deps (`markdown-it-py 4.0.0`, `mdurl 0.1.2`)