### PR TITLE
feat: --brief flag for concise 3-sentence summary output (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ why src/auth/middleware.py handle_session_timeout
 why --model llama-3.1-8b-instant src/auth/middleware.py
 ```
 
+### Get a 3-sentence summary
+
+```bash
+why --brief src/auth/middleware.py        # concise mode: one paragraph
+```
+
+### Verify claim grounding (two-pass)
+
+```bash
+why --verify src/auth/middleware.py       # second LLM call checks intent claims
+```
+
 ### Disable color / pipe-friendly output
 
 ```bash

--- a/docs/designs/2026-04-25-brief-flag-design.md
+++ b/docs/designs/2026-04-25-brief-flag-design.md
@@ -1,0 +1,79 @@
+# --brief Flag (Concise Mode)
+
+**Issue:** #29  
+**Date:** 2026-04-25  
+**Status:** Approved
+
+---
+
+## Problem
+
+The default `why` output is a full sectioned narrative. Users who want a quick orientation — not a deep archaeology — have no way to ask for a shorter answer.
+
+---
+
+## Desired Behaviour
+
+`why <target> --brief` emits a 3-sentence summary instead of the full narrative. All other pipeline behaviour is unchanged:
+- Timeline section still appended by `validate_and_repair_timeline()`
+- `--verify` can be combined with `--brief` (user opts into the cost)
+- Citation validation still runs
+
+---
+
+## Approach: Append tail in `build_why_prompt()` (Approach A)
+
+Add `brief: bool = False` to `build_why_prompt()`. When `True`, append a brief-mode instruction as a final section in the user message before returning. The instruction overrides the format rules from the system prompt for this call.
+
+The tail text (verbatim from issue spec):
+
+```
+## Output Format
+
+Output ONLY a 3-sentence summary. No sections, no citations block (inline only).
+```
+
+---
+
+## Implementation Plan
+
+### 1. `src/why/prompts.py`
+
+Add `brief: bool = False` to `build_why_prompt()`. When set, append the tail section to `content` before returning.
+
+### 2. `src/why/synth.py`
+
+Add `brief: bool = False` to `synthesize_why()`. Pass through to `build_why_prompt()`.
+
+### 3. `src/why/cli.py`
+
+Add `--brief` flag:
+
+```python
+@click.option(
+    "--brief",
+    is_flag=True,
+    default=False,
+    help="Emit a 3-sentence summary instead of the full narrative.",
+)
+```
+
+Wire to `synthesize_why(..., brief=brief)`.
+
+---
+
+## Decisions
+
+- **Timeline**: not suppressed — `validate_and_repair_timeline()` runs as normal
+- **`--brief` + `--verify`**: both allowed; user opts into the extra LLM call
+- **Prompt placement**: tail appended to user message (not system prompt) so it acts as a per-call format override
+
+---
+
+## Acceptance Criteria
+
+- [ ] `--brief` flag on CLI
+- [ ] Prompt appended with: `Output ONLY a 3-sentence summary. No sections, no citations block (inline only).`
+- [ ] `synthesize_why(..., brief=True)` passes the flag to `build_why_prompt()`
+- [ ] Single-pass mode without `--brief` is unchanged
+- [ ] Tests: assert brief tail appears in `messages[0].content` when `brief=True`; assert it is absent when `brief=False`

--- a/docs/sleipnir/state.json
+++ b/docs/sleipnir/state.json
@@ -1,12 +1,12 @@
 {
-  "branch": "sleipnir/issue-72-two-pass-synthesis",
+  "branch": "sleipnir/issue-29-brief-flag",
   "base_ref": "origin/main",
-  "base_sha": "97850fc7ea79c57d83ec5873ecaf2983ea9e5537",
-  "merge_base": "97850fc7ea79c57d83ec5873ecaf2983ea9e5537",
+  "base_sha": "036fd40",
+  "merge_base": "036fd40",
   "dirty_files": [],
   "included_files": [],
   "excluded_files": [".python-version"],
-  "issue": 72,
-  "design_doc": "docs/designs/2026-04-25-two-pass-synthesis-design.md",
+  "issue": 29,
+  "design_doc": "docs/designs/2026-04-25-brief-flag-design.md",
   "phase": "execution"
 }

--- a/src/why/cli.py
+++ b/src/why/cli.py
@@ -50,7 +50,20 @@ ARGUMENTS:
         "Adds ~1 LLM call of latency and cost."
     ),
 )
-def main(target_spec: str, extra: str | None, model: str, no_color: bool, verify: bool) -> None:
+@click.option(
+    "--brief",
+    is_flag=True,
+    default=False,
+    help="Emit a 3-sentence summary instead of the full narrative.",
+)
+def main(
+    target_spec: str,
+    extra: str | None,
+    model: str,
+    no_color: bool,
+    verify: bool,
+    brief: bool,
+) -> None:
     """Explain why code is the way it is via git history and LLM synthesis."""
     cwd = Path.cwd()
 
@@ -62,7 +75,7 @@ def main(target_spec: str, extra: str | None, model: str, no_color: bool, verify
 
     try:
         llm = LLMClient(model)
-        output = synthesize_why(target, cwd, llm, two_pass=verify)
+        output = synthesize_why(target, cwd, llm, two_pass=verify, brief=brief)
     except (LLMError, GitError, SymbolNotFoundError) as exc:
         click.echo(f"Error: {exc}", err=True)
         sys.exit(1)

--- a/src/why/prompts.py
+++ b/src/why/prompts.py
@@ -333,11 +333,18 @@ def _render_timeline_data(
 # Public API
 # ---------------------------------------------------------------------------
 
+_BRIEF_TAIL: str = (
+    "\n\n---\n\n## Output Format\n\n"
+    "Output ONLY a 3-sentence summary."
+    " No sections, no citations block (inline only)."
+)
+
 
 def build_why_prompt(
     target: Target,
     current_code: str,
     key_commits: list[CommitWithPR],
+    brief: bool = False,
 ) -> list[Message]:
     """Build the user message payload for the why LLM synthesis call.
 
@@ -392,6 +399,9 @@ def build_why_prompt(
         target_section, code_section, *sparse_sections, commits_section, timeline_section
     ]
     content = "\n\n---\n\n".join(all_sections)
+
+    if brief:
+        content += _BRIEF_TAIL
 
     return [Message(role="user", content=content)]
 

--- a/src/why/synth.py
+++ b/src/why/synth.py
@@ -134,6 +134,7 @@ def synthesize_why(
     prs: dict[str, str] | None = None,
     strict: bool = False,
     two_pass: bool = False,
+    brief: bool = False,
 ) -> str:
     """Orchestrate the full why pipeline and return the LLM's explanation.
 
@@ -191,7 +192,7 @@ def synthesize_why(
         for c in key_commits
     ]
 
-    messages = build_why_prompt(target, current_code, commits_with_prs)
+    messages = build_why_prompt(target, current_code, commits_with_prs, brief=brief)
     repo_url = _get_repo_url(repo)
     result = llm.complete(build_system_prompt(repo_url), messages)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -511,3 +511,45 @@ def test_verify_flag_help_text() -> None:
     assert result.exit_code == 0
     assert "--verify" in result.output
     assert "two-pass" in result.output or "grounding" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --brief flag tests
+# ---------------------------------------------------------------------------
+
+
+def test_brief_flag_passes_brief_true_to_synthesize(existing_file: Path) -> None:
+    """--brief → synthesize_why called with brief=True."""
+    with (
+        patch("why.cli.Path") as mock_path_cls,
+        patch("why.cli.LLMClient") as mock_llm_cls,
+        patch("why.cli.synthesize_why", return_value="explanation") as mock_synth,
+    ):
+        mock_llm_cls.return_value = MagicMock()
+        mock_path_cls.cwd.return_value = existing_file.parent
+        result = CliRunner().invoke(main, ["--brief", str(existing_file)])
+    assert result.exit_code == 0, result.output
+    _, kwargs = mock_synth.call_args
+    assert kwargs.get("brief") is True
+
+
+def test_no_brief_flag_passes_brief_false_to_synthesize(existing_file: Path) -> None:
+    """Without --brief → synthesize_why called with brief=False."""
+    with (
+        patch("why.cli.Path") as mock_path_cls,
+        patch("why.cli.LLMClient") as mock_llm_cls,
+        patch("why.cli.synthesize_why", return_value="explanation") as mock_synth,
+    ):
+        mock_llm_cls.return_value = MagicMock()
+        mock_path_cls.cwd.return_value = existing_file.parent
+        result = CliRunner().invoke(main, [str(existing_file)])
+    assert result.exit_code == 0, result.output
+    _, kwargs = mock_synth.call_args
+    assert kwargs.get("brief") is False
+
+
+def test_brief_flag_help_text() -> None:
+    """--help output includes --brief."""
+    result = CliRunner().invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "--brief" in result.output

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -509,3 +509,37 @@ def test_build_grounding_prompt_with_empty_commits() -> None:
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].role == "user"
+
+
+# ---------------------------------------------------------------------------
+# --brief flag tests (Stride 1 of Issue #29)
+# ---------------------------------------------------------------------------
+
+
+def test_build_why_prompt_brief_appends_tail() -> None:
+    """When brief=True, message content contains the brief-mode summary instruction."""
+    commits = [CommitWithPR(commit=FIXED_COMMIT)]
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits, brief=True)
+    assert "Output ONLY a 3-sentence summary" in result[0].content
+
+
+def test_build_why_prompt_brief_tail_exact_text() -> None:
+    """When brief=True, the exact tail string must appear verbatim in message content."""
+    commits = [CommitWithPR(commit=FIXED_COMMIT)]
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits, brief=True)
+    assert "Output ONLY a 3-sentence summary." in result[0].content
+    assert "No sections, no citations block (inline only)." in result[0].content
+
+
+def test_build_why_prompt_no_brief_omits_tail() -> None:
+    """When brief=False (default), content must NOT contain the brief-mode instruction."""
+    commits = [CommitWithPR(commit=FIXED_COMMIT)]
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
+    assert "Output ONLY a 3-sentence summary" not in result[0].content
+
+
+def test_build_why_prompt_brief_section_header() -> None:
+    """When brief=True, content must contain the '## Output Format' section header."""
+    commits = [CommitWithPR(commit=FIXED_COMMIT)]
+    result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits, brief=True)
+    assert "## Output Format" in result[0].content

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -342,7 +342,7 @@ class TestSynthesizeWhyPRBodyWiring:
 
         captured_commits_with_prs = []
 
-        def fake_build_prompt(t, code, cwprs):
+        def fake_build_prompt(t, code, cwprs, **kwargs):
             captured_commits_with_prs.extend(cwprs)
             return [MagicMock()]
 
@@ -424,7 +424,7 @@ class TestSynthesizeWhyGitErrorHandling:
 
         captured: list = []
 
-        def fake_build_prompt(t, code, cwprs):
+        def fake_build_prompt(t, code, cwprs, **kwargs):
             captured.extend(cwprs)
             return [MagicMock()]
 
@@ -480,7 +480,7 @@ class TestSynthesizeWhySparseHistoryOrdering:
 
         captured_order: list = []
 
-        def fake_build_prompt(t, code, cwprs):
+        def fake_build_prompt(t, code, cwprs, **kwargs):
             captured_order.extend(cwprs)
             return [MagicMock()]
 
@@ -943,3 +943,61 @@ class TestSynthesizeWhyTwoPass:
         assert call_args.args[0].startswith(first_pass_text)
         assert isinstance(call_args.args[1], list)
         assert len(call_args.args[1]) > 0
+
+
+# ---------------------------------------------------------------------------
+# brief flag pass-through tests
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizeWhyBriefFlag:
+    """brief=True/False is forwarded to build_why_prompt as a keyword argument."""
+
+    def _make_setup(self, tmp_path: Path):
+        sha = "abc1234def5678901234567890"
+        commits = [_make_commit(sha)]
+        f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
+        target = Target(file=f)
+        return commits, f, target
+
+    def test_synthesize_why_brief_passes_brief_true_to_build_prompt(
+        self, tmp_path: Path
+    ) -> None:
+        commits, _f, target = self._make_setup(tmp_path)
+        llm = MagicMock()
+        llm.complete.return_value = "answer"
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]) as mock_build_prompt,
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
+            synthesize_why(target, tmp_path, llm, brief=True)
+
+        call_kwargs = mock_build_prompt.call_args.kwargs
+        assert call_kwargs.get("brief") is True
+
+    def test_synthesize_why_no_brief_passes_brief_false_to_build_prompt(
+        self, tmp_path: Path
+    ) -> None:
+        commits, _f, target = self._make_setup(tmp_path)
+        llm = MagicMock()
+        llm.complete.return_value = "answer"
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]) as mock_build_prompt,
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
+            synthesize_why(target, tmp_path, llm)
+
+        call_kwargs = mock_build_prompt.call_args.kwargs
+        assert call_kwargs.get("brief") is False


### PR DESCRIPTION
## Related Links

Closes #29

## What

Adds `--brief` CLI flag that produces a 3-sentence summary instead of the full sectioned narrative.

## Why

Users who want a quick orientation — not a deep archaeology — had no way to ask for a shorter answer. The brief mode appends a format-override instruction to the user message that the LLM uses to constrain its output.

## How

- `src/why/prompts.py` — `_BRIEF_TAIL` constant + `brief: bool = False` on `build_why_prompt()`. When set, the tail is appended after all existing sections as a final `## Output Format` instruction.
- `src/why/synth.py` — `brief: bool = False` on `synthesize_why()`; passed through to `build_why_prompt()`.
- `src/why/cli.py` — `--brief` is_flag wired to `brief=True`. Composes freely with `--verify`.
- `README.md` — `--brief` and `--verify` usage examples added.
- Single-pass mode without `--brief` is byte-for-byte identical to before.

## Test Steps

- [ ] `uv run pytest -x -q` — 235 tests pass
- [ ] `why <file> --brief` — output is a short paragraph, not full sections
- [ ] `why <file>` (no flag) — output unchanged
- [ ] `why --help` — `--brief` appears with description
- [ ] `why <file> --brief --verify` — both flags compose without error