### PR TITLE
feat: source PR number from PRMetadata instead of parsing pr_body text

### DIFF
--- a/src/why/prompts.py
+++ b/src/why/prompts.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
+from typing import NamedTuple
 
 from why.commit import Commit
 from why.llm import Message
@@ -186,12 +186,20 @@ WHY_SYSTEM_PROMPT: str = build_system_prompt()  # no-URL fallback
 # ---------------------------------------------------------------------------
 
 
+class PRMetadata(NamedTuple):
+    """PR number and body text sourced from VCS metadata."""
+
+    number: int
+    body: str
+
+
 @dataclass(frozen=True)
 class CommitWithPR:
     """A commit paired with its associated PR description and diff patch."""
 
     commit: Commit
     pr_body: str | None = None
+    pr_number: int | None = None
     diff: str = ""  # patch text from get_commit_diff(); empty = not yet fetched
 
 
@@ -295,8 +303,7 @@ def _render_timeline_data(
     having to re-derive them from the fuller Commits section.
 
     Each row format: `<YYYY-MM-DD>  <short_sha>  <subject>  [PR #N]`
-    The `[PR #N]` suffix is only appended when a PR number can be extracted
-    from the commit's pr_body via the `PR #\d+` pattern.
+    The `[PR #N]` suffix is only appended when `cwpr.pr_number` is set (not None).
     """
     header = (
         "## Timeline Data\n\n"
@@ -313,12 +320,8 @@ def _render_timeline_data(
         # Strip newlines from subject to prevent Markdown injection
         safe_subject = commit.subject.replace("\n", " ").replace("\r", "")
 
-        # Attempt to extract a PR number from the PR body text
-        pr_label = ""
-        if cwpr.pr_body:
-            match = re.search(r"PR\s*#(\d+)", cwpr.pr_body)
-            if match:
-                pr_label = f"  [PR #{match.group(1)}]"
+        # Use the explicit pr_number field (source of truth) for the PR annotation
+        pr_label = f"  [PR #{cwpr.pr_number}]" if cwpr.pr_number is not None else ""
 
         rows.append(f"{date_str}  {commit.short_sha}  {safe_subject}{pr_label}")
 

--- a/src/why/scoring.py
+++ b/src/why/scoring.py
@@ -61,6 +61,7 @@ from datetime import date
 from math import log
 
 from .commit import Commit
+from .prompts import PRMetadata
 
 # Keywords that signal a meaningful commit — each occurrence adds _KEYWORD_BONUS points.
 KEYWORDS = [
@@ -189,7 +190,7 @@ def score_commit(c: Commit, now: date, has_pr: bool) -> float:
 
 def select_key_commits(
     commits: list[Commit],
-    prs: Mapping[str, object],  # SHA -> PR object; only membership (sha in prs) is checked
+    prs: Mapping[str, PRMetadata],  # SHA -> PRMetadata; only membership (sha in prs) is checked
     n: int = 5,
     now: date | None = None,
 ) -> list[Commit]:

--- a/src/why/synth.py
+++ b/src/why/synth.py
@@ -17,6 +17,7 @@ from why.llm import LLMClient, Message
 from why.prompts import (
     GROUNDING_SYSTEM_PROMPT,
     CommitWithPR,
+    PRMetadata,
     build_grounding_prompt,
     build_system_prompt,
     build_why_prompt,
@@ -142,7 +143,7 @@ def synthesize_why(
     target: Target,
     repo: Path,
     llm: LLMClient,
-    prs: dict[str, str] | None = None,
+    prs: dict[str, PRMetadata] | None = None,
     strict: bool = False,
     two_pass: bool = False,
     brief: bool = False,
@@ -152,7 +153,7 @@ def synthesize_why(
     """Orchestrate the full why pipeline and return the LLM's explanation.
 
     Steps:
-      1. Normalise prs to an empty dict when callers pass None.
+      1. Normalise prs (dict[str, PRMetadata]) to an empty dict when callers pass None.
       2. Fetch the relevant commit history (line-scoped when target.line is set,
          file-scoped otherwise).
       3. Short-circuit with a sentinel string when there are no commits.
@@ -203,10 +204,17 @@ def synthesize_why(
 
     current_code = _extract_current_code(target, line_range)
 
-    commits_with_prs = [
-        CommitWithPR(commit=c, pr_body=prs.get(c.sha), diff=diffs[c.sha])
-        for c in key_commits
-    ]
+    commits_with_prs = []
+    for c in key_commits:
+        meta = prs.get(c.sha)
+        commits_with_prs.append(
+            CommitWithPR(
+                commit=c,
+                pr_body=meta.body if meta else None,
+                pr_number=meta.number if meta else None,
+                diff=diffs[c.sha],
+            )
+        )
 
     messages = build_why_prompt(target, current_code, commits_with_prs, brief=brief)
     repo_url = _get_repo_url(repo)
@@ -225,10 +233,11 @@ def synthesize_why(
     result = llm.complete(system_prompt, messages)
 
     # Post-process: validate every SHA mentioned in the LLM output against the
-    # set of SHAs we actually provided in context.  PR numbers aren't available
-    # from the prs dict (it maps sha → body), so pass an empty set for now.
+    # set of SHAs we actually provided in context.  PR numbers come from PRMetadata,
+    # scoped to commits_with_prs so we only accept citations the LLM was shown.
     known_shas = {c.sha for c in key_commits}
-    issues = validate_citations(result, known_shas, known_prs=set(), strict=strict)
+    known_prs = {cwpr.pr_number for cwpr in commits_with_prs if cwpr.pr_number is not None}
+    issues = validate_citations(result, known_shas, known_prs=known_prs, strict=strict)
     for issue in issues:
         # Strip non-printable characters from issue.value before logging to
         # prevent control codes or ANSI escapes from polluting log output.

--- a/src/why/timeline.py
+++ b/src/why/timeline.py
@@ -21,7 +21,7 @@ def render_deterministic_timeline(key_commits: list[CommitWithPR]) -> str:
 
     Iterates key_commits in the order provided (callers pass a sorted list).
     Each row is: ``YYYY-MM-DD  <short_sha>  <subject>`` with an optional
-    ``  [PR #N]`` suffix when the commit's pr_body references a PR number.
+    ``  [PR #N]`` suffix when the commit's pr_number field is set.
 
     Returns a plain "No commit history available." message when the list is empty.
     """
@@ -37,11 +37,9 @@ def render_deterministic_timeline(key_commits: list[CommitWithPR]) -> str:
 
         row = f"{date_str}  {short_sha}  {safe_subject}"
 
-        # Append PR annotation if the pr_body contains a PR number reference
-        if cwpr.pr_body:
-            pr_match = re.search(r"PR\s*#(\d+)", cwpr.pr_body)
-            if pr_match:
-                row += f"  [PR #{pr_match.group(1)}]"
+        # Append PR annotation using the explicit pr_number field (source of truth)
+        if cwpr.pr_number is not None:
+            row += f"  [PR #{cwpr.pr_number}]"
 
         rows.append(row)
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -8,12 +8,15 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 from why.commit import Commit
 from why.llm import Message
 from why.prompts import (
     GROUNDING_SYSTEM_PROMPT,
     WHY_SYSTEM_PROMPT,
     CommitWithPR,
+    PRMetadata,
     build_grounding_prompt,
     build_system_prompt,
     build_why_prompt,
@@ -413,12 +416,30 @@ def test_timeline_data_single_commit_no_pr() -> None:
 
 
 def test_timeline_data_single_commit_with_pr() -> None:
-    """A commit with pr_body containing 'PR #42' must render [PR #42] in the row."""
+    """A commit with pr_number=42 must render [PR #42] in the row."""
     from why.prompts import _render_timeline_data
 
-    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_body="Merged PR #42: fix the thing")
+    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_number=42)
     result = _render_timeline_data([cwpr])
     assert "[PR #42]" in result
+
+
+def test_timeline_data_pr_number_used_not_pr_body_regex() -> None:
+    """pr_number=None means NO [PR #N] label even if pr_body contains 'PR #42'."""
+    from why.prompts import _render_timeline_data
+
+    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_number=None, pr_body="Merged PR #42: fix")
+    result = _render_timeline_data([cwpr])
+    assert "[PR #" not in result
+
+
+def test_timeline_data_pr_number_overrides_body() -> None:
+    """When pr_number=7, [PR #7] appears regardless of pr_body content."""
+    from why.prompts import _render_timeline_data
+
+    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_number=7, pr_body="unrelated body text")
+    result = _render_timeline_data([cwpr])
+    assert "[PR #7]" in result
 
 
 def test_timeline_data_section_in_user_message() -> None:
@@ -543,3 +564,63 @@ def test_build_why_prompt_brief_section_header() -> None:
     commits = [CommitWithPR(commit=FIXED_COMMIT)]
     result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits, brief=True)
     assert "## Output Format" in result[0].content
+
+
+# ---------------------------------------------------------------------------
+# PRMetadata NamedTuple tests (Stride 1 of Issue #76)
+# ---------------------------------------------------------------------------
+
+
+def test_prmetadata_construction() -> None:
+    """PRMetadata can be constructed with number and body fields."""
+    meta = PRMetadata(number=42, body="Fixes #99: adds null check")
+    assert meta.number == 42
+    assert meta.body == "Fixes #99: adds null check"
+
+
+def test_prmetadata_fields_accessible_by_name() -> None:
+    """PRMetadata fields are accessible by attribute name."""
+    meta = PRMetadata(number=7, body="some body text")
+    assert meta.number == 7
+    assert meta.body == "some body text"
+
+
+def test_prmetadata_is_namedtuple() -> None:
+    """PRMetadata is a NamedTuple and supports tuple unpacking."""
+    meta = PRMetadata(number=1, body="test")
+    number, body = meta
+    assert number == 1
+    assert body == "test"
+
+
+# ---------------------------------------------------------------------------
+# CommitWithPR.pr_number field tests (Stride 1 of Issue #76)
+# ---------------------------------------------------------------------------
+
+
+def test_commitwithpr_pr_number_defaults_to_none() -> None:
+    """CommitWithPR.pr_number defaults to None when not supplied."""
+    cwpr = CommitWithPR(commit=FIXED_COMMIT)
+    assert cwpr.pr_number is None
+
+
+def test_commitwithpr_pr_number_can_be_set() -> None:
+    """CommitWithPR can be constructed with an explicit pr_number."""
+    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_number=42)
+    assert cwpr.pr_number == 42
+
+
+def test_commitwithpr_pr_number_with_pr_body() -> None:
+    """CommitWithPR accepts both pr_number and pr_body simultaneously."""
+    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_number=99, pr_body="Fixes #99")
+    assert cwpr.pr_number == 99
+    assert cwpr.pr_body == "Fixes #99"
+
+
+def test_commitwithpr_is_still_frozen() -> None:
+    """CommitWithPR remains a frozen dataclass — assignment must raise FrozenInstanceError."""
+    import dataclasses
+
+    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_number=1)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cwpr.pr_number = 2  # type: ignore[misc]

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -329,12 +329,14 @@ class TestSynthesizeWhyPRBodyWiring:
     """prs dict is forwarded to select_key_commits AND populates CommitWithPR.pr_body."""
 
     def test_pr_body_populated_for_matching_shas(self, tmp_path: Path) -> None:
+        from why.prompts import PRMetadata
+
         sha_a = "aaa0" * 10
         sha_b = "bbb0" * 10
         sha_c = "ccc0" * 10
         commits = [_make_commit(sha_a), _make_commit(sha_b), _make_commit(sha_c)]
-        # Only sha_a has a PR body; sha_c does not
-        prs = {sha_a: "PR body for A"}
+        # Only sha_a has a PR; sha_b and sha_c do not
+        prs: dict[str, PRMetadata] = {sha_a: PRMetadata(number=42, body="PR body for A")}
         f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
         target = Target(file=f)
         llm = MagicMock()
@@ -364,6 +366,110 @@ class TestSynthesizeWhyPRBodyWiring:
         assert pr_bodies[sha_a] == "PR body for A"
         assert pr_bodies[sha_b] is None
         assert pr_bodies[sha_c] is None
+
+    def test_pr_number_populated_from_metadata(self, tmp_path: Path) -> None:
+        """CommitWithPR.pr_number is taken from PRMetadata.number; missing SHAs get None."""
+        from why.prompts import PRMetadata
+
+        sha_a = "aaa1" * 10
+        sha_b = "bbb1" * 10
+        commits = [_make_commit(sha_a), _make_commit(sha_b)]
+        prs: dict[str, PRMetadata] = {sha_a: PRMetadata(number=99, body="body A")}
+        f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
+        target = Target(file=f)
+        llm = MagicMock()
+        llm.complete.return_value = "answer"
+
+        captured: list = []
+
+        def fake_build_prompt(t, code, cwprs, **kwargs):
+            captured.extend(cwprs)
+            return [MagicMock()]
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT, return_value=commits),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, side_effect=fake_build_prompt),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
+            synthesize_why(target, tmp_path, llm, prs=prs)
+
+        pr_numbers = {cwpr.commit.sha: cwpr.pr_number for cwpr in captured}
+        assert pr_numbers[sha_a] == 99
+        assert pr_numbers[sha_b] is None
+
+    def test_known_prs_populated_from_metadata_numbers(self, tmp_path: Path) -> None:
+        """validate_citations receives known_prs built from PRMetadata.number values."""
+        from why.prompts import PRMetadata
+
+        sha_a = "aaa2" * 10
+        commits = [_make_commit(sha_a)]
+        prs: dict[str, PRMetadata] = {sha_a: PRMetadata(number=77, body="body")}
+        f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
+        target = Target(file=f)
+        llm = MagicMock()
+        llm.complete.return_value = "answer"
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT, return_value=commits),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+            patch(_PATCH_VALIDATE_CITATIONS, return_value=[]) as mock_validate,
+        ):
+            synthesize_why(target, tmp_path, llm, prs=prs)
+
+        mock_validate.assert_called_once()
+        call_kwargs = mock_validate.call_args.kwargs
+        assert call_kwargs.get("known_prs") == {77}
+
+    def test_known_prs_scoped_to_key_commits_not_all_prs(self, tmp_path: Path) -> None:
+        """known_prs must not include PR numbers for commits excluded by select_key_commits.
+
+        select_key_commits is only invoked when history has >= 3 commits, so we
+        supply three commits in history but patch the selector to return only the
+        key one — verifying that the non-key commit's PR number is excluded.
+        """
+        from why.prompts import PRMetadata
+
+        sha_key = "key0" * 10
+        sha_nonkey1 = "no10" * 10
+        sha_nonkey2 = "no20" * 10
+        all_commits = [_make_commit(sha_key), _make_commit(sha_nonkey1), _make_commit(sha_nonkey2)]
+        # All three SHAs have PR entries, but only sha_key is selected as a key commit
+        prs: dict[str, PRMetadata] = {
+            sha_key: PRMetadata(number=10, body="key PR"),
+            sha_nonkey1: PRMetadata(number=99, body="non-key PR 1"),
+            sha_nonkey2: PRMetadata(number=100, body="non-key PR 2"),
+        }
+        f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
+        target = Target(file=f)
+        llm = MagicMock()
+        llm.complete.return_value = "answer"
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=all_commits),
+            patch(_PATCH_SELECT, return_value=[_make_commit(sha_key)]),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+            patch(_PATCH_VALIDATE_CITATIONS, return_value=[]) as mock_validate,
+        ):
+            synthesize_why(target, tmp_path, llm, prs=prs)
+
+        call_kwargs = mock_validate.call_args.kwargs
+        # PRs #99 and #100 are for non-key commits — must not appear in known_prs
+        assert call_kwargs.get("known_prs") == {10}
+        assert 99 not in call_kwargs.get("known_prs", set())
+        assert 100 not in call_kwargs.get("known_prs", set())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -64,11 +64,25 @@ def test_deterministic_single_no_pr() -> None:
 
 
 def test_deterministic_single_with_pr() -> None:
-    """Single commit whose pr_body contains 'PR #42' gets [PR #42] appended to row."""
-    cwpr_with_pr = CommitWithPR(commit=FIXED_COMMIT, pr_body="PR #42 description")
+    """Single commit with pr_number=42 gets [PR #42] appended to row."""
+    cwpr_with_pr = CommitWithPR(commit=FIXED_COMMIT, pr_number=42)
     result = _render_deterministic_timeline([cwpr_with_pr])
     assert "[PR #42]" in result
     assert "abc1234" in result
+
+
+def test_deterministic_pr_number_used_not_pr_body_regex() -> None:
+    """pr_number=None means NO [PR #N] annotation even if pr_body contains 'PR #99'."""
+    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_number=None, pr_body="PR #99 mentioned here")
+    result = _render_deterministic_timeline([cwpr])
+    assert "[PR #" not in result
+
+
+def test_deterministic_pr_number_overrides_body() -> None:
+    """When pr_number=7 is set, [PR #7] appears regardless of pr_body content."""
+    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_number=7, pr_body="some unrelated body")
+    result = _render_deterministic_timeline([cwpr])
+    assert "[PR #7]" in result
 
 
 def test_deterministic_subject_newlines_stripped() -> None:


### PR DESCRIPTION
## Related Links
- Closes #76

## What
- Introduce `PRMetadata(number: int, body: str)` NamedTuple as the value type for the `prs` dict passed to `synthesize_why`
- Add `pr_number: int | None = None` field to `CommitWithPR`
- Delete the `re.search(r"PR\s*#(\d+)", cwpr.pr_body)` regex from both `render_deterministic_timeline` and `_render_timeline_data` — replace with direct `cwpr.pr_number` access
- Scope `known_prs` in citation validation to `commits_with_prs` only (not all `prs.values()`), consistent with how `known_shas` is computed
- Tighten `scoring.py` `select_key_commits` annotation from `Mapping[str, object]` to `Mapping[str, PRMetadata]`

## Why
`[PR #N]` was absent on virtually every commit because PR bodies almost never self-reference their own number — the regex never matched. The PR number is metadata that callers already have at the time they construct the `prs` dict; it just wasn't being carried through the data model.

Scoping `known_prs` to key commits prevents PR numbers from filtered-out commits from suppressing hallucination warnings in citation validation.

## How
`PRMetadata` is a `NamedTuple` — it remains a plain tuple so `sha in prs` membership checks in `scoring.py` work unchanged. Both rendering sites now read `cwpr.pr_number` directly; the regex is gone entirely.

## Test Steps
- [ ] `uv run pytest` — 266 tests pass
- [ ] New tests verify: `PRMetadata` construction/unpacking, `CommitWithPR.pr_number` default/set, `[PR #N]` appears when `pr_number` is set, `[PR #N]` absent when `pr_number=None` even if `pr_body` contains "PR #42", `known_prs` excludes non-key-commit PR numbers

## Other Notes
`PRMetadata` lives in `prompts.py` alongside `CommitWithPR` for now. A future refactor could move both to a shared `types.py` as the module grows.