### PR TITLE
feat: M2 GitHub PR integration — fetch PR context for key commits

### DIFF
--- a/docs/designs/2026-04-26-github-pr-integration-design.md
+++ b/docs/designs/2026-04-26-github-pr-integration-design.md
@@ -1,0 +1,215 @@
+# Design: M2 GitHub PR Integration (#24–#27)
+
+**Date:** 2026-04-26  
+**Issues:** #24 (fetch PR for SHA), #25 (PR cache), #26 (prompt injection), #27 (synthesizer wiring)  
+**Milestone:** M2 — GitHub PR integration
+
+---
+
+## Problem
+
+`why` mines git history to explain code decisions, but commit messages are often thin ("fix bug", "update logic"). PR bodies carry the richer context: the *why*, the trade-offs considered, the issue link. Today `synthesize_why` accepts a `prs: dict[str, PRMetadata]` parameter but the CLI always passes `None` — the plumbing exists, the data source does not.
+
+---
+
+## Goals
+
+- Implement `GitHubClient.get_prs_for_commit(sha)` using the GitHub REST API
+- Cache results SHA-keyed in `~/.cache/why/` (XDG-aware, 30-day TTL)
+- Add `title` to `PRMetadata` and inject `PR #N: Title` + body into the prompt
+- Wire PR fetching into `synthesize_why` after key-commit selection (fetch ≤5 commits)
+- Degrade gracefully: missing token, API error, non-GitHub remote → proceed without PRs
+
+## Non-goals
+
+- Scoring boost from PR membership at selection time (left for M3 — requires prefetching all history commits)
+- GitLab / Bitbucket MR support
+- GitHub App authentication (token-based only for now)
+
+---
+
+## Solution
+
+### 1. `PRMetadata` schema change (prompts.py)
+
+Add `title` field. All callers that construct `PRMetadata` must supply it.
+
+```python
+class PRMetadata(NamedTuple):
+    number: int
+    title: str
+    body: str
+```
+
+### 2. New module: `src/why/github.py`
+
+```
+GitHubClient
+  __init__(repo_url: str, token: str | None)
+  get_prs_for_commit(sha: str, cache: PRCache | None) -> list[PRMetadata]
+  _fetch_prs(sha: str) -> list[PRMetadata]          # raw API call
+  _parse_remote(repo_url: str) -> tuple[str, str]   # owner, repo
+
+def detect_github_token() -> str | None
+  # 1. GITHUB_TOKEN env var
+  # 2. gh auth token (subprocess, silent on failure)
+  # 3. None
+
+def get_github_remote(repo: Path) -> str | None
+  # git remote get-url origin → filter for github.com URLs
+```
+
+**API endpoint:** `GET /repos/{owner}/{repo}/commits/{sha}/pulls`  
+**Transport:** `urllib.request` (stdlib, no new dep)  
+**Auth header:** `Authorization: Bearer <token>` when token available  
+**Accept header:** `application/vnd.github+json`  
+**Rate limits:** Authenticated = 5000 req/hr, unauthenticated = 60 req/hr
+
+**Error handling:**
+- `401/403` → log warning "GitHub auth failed, proceeding without PRs", return `[]`
+- `404` → return `[]` (commit not in repo, valid state)
+- `422` → return `[]` (SHA not a valid commit)
+- Network/timeout → log warning, return `[]`
+- Non-GitHub remote → skip entirely (no `GitHubClient` constructed)
+
+### 3. New module: `src/why/cache.py`
+
+```
+PRCache
+  __init__(repo_slug: str)   # repo_slug = "owner__repo"
+  path: Path                 # XDG_CACHE_HOME/why/<repo_slug>.json
+  get(sha: str) -> list[PRMetadata] | None
+  set(sha: str, prs: list[PRMetadata]) -> None
+  _is_expired(entry: dict) -> bool   # >30 days since "cached_at"
+
+def xdg_cache_dir() -> Path
+  # os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache"
+```
+
+**Cache file format:**
+```json
+{
+  "abc1234...": {
+    "cached_at": "2026-04-26T12:00:00Z",
+    "prs": [{"number": 42, "title": "Fix the thing", "body": "..."}]
+  }
+}
+```
+
+**`--no-cache` flag:** Added to CLI; when set, `PRCache` is not passed to `get_prs_for_commit`, forcing a fresh fetch.
+
+### 4. Prompt injection update (prompts.py, issue #26)
+
+In `build_why_prompt`, the commit block for a PR-backed commit changes from:
+
+```
+**PR Body:**
+```text
+<body or N/A>
+```
+```
+
+to:
+
+```
+**PR [#42](…/pull/42): Fix the thing**
+```text
+<body truncated to 1000 chars>
+```
+```
+
+When no PR: the section is omitted entirely (cleaner than "N/A").
+
+Truncation: `body[:1000] + " …"` if `len(body) > 1000`.
+
+### 5. Synthesizer wiring (synth.py + cli.py, issue #27)
+
+**Fetch timing: after key-commit selection.**
+
+```
+git history → select_key_commits() → [up to 5 commits]
+                                          ↓
+                               GitHubClient.get_prs_for_commit(sha)  ← NEW
+                               (for each key commit, with cache)
+                                          ↓
+                               prs: dict[str, PRMetadata]
+                                          ↓
+                               build_why_prompt(..., commits_with_prs)
+```
+
+**`synthesize_why` change:** The function already accepts `prs` and passes it through. No signature change needed — the CLI layer populates it.
+
+**CLI change (`cli.py`):**
+```python
+# After target/repo parsing, before synthesize_why call:
+github_remote = get_github_remote(repo)
+prs: dict[str, PRMetadata] = {}
+if github_remote:
+    token = detect_github_token()
+    client = GitHubClient(github_remote, token)
+    cache = None if no_cache else PRCache(repo_slug)
+    # key_commits derived after synthesis — need to expose them
+    # OR: fetch inside synthesize_why after key commit selection
+```
+
+**Decision:** Fetch inside `synthesize_why`, not in CLI. The CLI doesn't have access to key commits (they're selected inside `synthesize_why`). Pass `GitHubClient | None` into `synthesize_why` instead of a pre-built `prs` dict.
+
+Updated signature:
+```python
+def synthesize_why(
+    target: Target,
+    repo: Path,
+    llm: LLMClient,
+    gh: GitHubClient | None = None,      # NEW (replaces prs param)
+    pr_cache: PRCache | None = None,     # NEW
+    prs: dict[str, PRMetadata] | None = None,  # kept for direct callers / tests
+    ...
+) -> str:
+```
+
+Inside `synthesize_why`, after `select_key_commits`:
+```python
+if gh is not None:
+    for commit in key_commits:
+        fetched = gh.get_prs_for_commit(commit.sha, pr_cache)
+        if fetched:
+            resolved_prs[commit.sha] = fetched[0]  # take first PR (squash-merge norm)
+```
+
+`prs` parameter takes precedence if supplied (backward-compatible for tests).
+
+**Warning output:** When `gh` is provided but token is missing or API fails:
+```
+⚠  GitHub PR data unavailable — proceeding without PR context
+```
+
+---
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `src/why/github.py` | **New** — `GitHubClient`, `detect_github_token`, `get_github_remote` |
+| `src/why/cache.py` | **New** — `PRCache`, `xdg_cache_dir` |
+| `src/why/prompts.py` | Add `title` to `PRMetadata`; update commit block rendering |
+| `src/why/synth.py` | Add `gh` + `pr_cache` params; fetch PRs after key-commit selection |
+| `src/why/cli.py` | Detect GitHub remote; init `GitHubClient`; pass `--no-cache` flag |
+| `tests/test_github.py` | **New** — mocked API: 0/1/2 PRs, 401, 404, timeout |
+| `tests/test_cache.py` | **New** — cache hit/miss/expired |
+| `tests/test_prompts.py` | Update golden prompts for title field, body truncation |
+| `tests/test_synth.py` | Update for new `gh` param; mock `GitHubClient` |
+
+---
+
+## Test Plan
+
+- `test_github.py`: Mock `urllib.request.urlopen`; assert correct URL construction, header injection, response parsing for 0/1/2 PRs; assert `[]` on 401/404/timeout
+- `test_cache.py`: Cache miss → calls API; cache hit → skips API; expired entry → re-fetches; `--no-cache` → always fetches
+- `test_prompts.py`: Golden prompt with PR present (title + truncated body); golden prompt without PR (section omitted)
+- `test_synth.py`: `gh=MockClient` → `prs` dict populated after selection; `gh=None` → no PR fetch; API error → `prs` empty, synthesis continues
+
+---
+
+## Rollout
+
+All four issues ship together in one PR on branch `sleipnir/issue-24-27-github-pr-integration`. No feature flag needed — graceful degradation handles the unauthenticated case.

--- a/src/why/cache.py
+++ b/src/why/cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import tempfile
@@ -74,11 +75,8 @@ class PRCache:
                 json.dump(data, f, indent=2)
             os.replace(tmp_path, self.path)
         except Exception:
-            # Clean up temp file on failure
-            try:
+            with contextlib.suppress(OSError):
                 os.unlink(tmp_path)
-            except OSError:
-                pass
             raise
 
     def _is_expired(self, entry: dict) -> bool:

--- a/src/why/cache.py
+++ b/src/why/cache.py
@@ -1,0 +1,90 @@
+"""SHA-keyed local cache for GitHub PR metadata."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from why.prompts import PRMetadata
+
+_TTL = timedelta(days=30)
+
+
+def xdg_cache_dir() -> Path:
+    """Return XDG_CACHE_HOME if set, else ~/.cache"""
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg:
+        return Path(xdg)
+    return Path.home() / ".cache"
+
+
+class PRCache:
+    def __init__(self, repo_slug: str) -> None:
+        """
+        repo_slug: "owner__repo" (double underscore, safe for filenames)
+        Cache file: xdg_cache_dir() / "why" / f"{repo_slug}.json"
+        """
+        self.path: Path = xdg_cache_dir() / "why" / f"{repo_slug}.json"
+
+    def get(self, sha: str) -> list[PRMetadata] | None:
+        """Return cached PRs for sha, or None if not cached / expired / corrupt."""
+        data = self._load()
+        entry = data.get(sha)
+        if entry is None:
+            return None
+        if self._is_expired(entry):
+            return None
+        try:
+            return [
+                PRMetadata(number=pr["number"], title=pr["title"], body=pr["body"])
+                for pr in entry["prs"]
+            ]
+        except (KeyError, TypeError):
+            return None
+
+    def set(self, sha: str, prs: list[PRMetadata]) -> None:
+        """Write prs to cache under sha key. Creates parent directories if needed."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        data = self._load()
+        data[sha] = {
+            "cached_at": datetime.now(UTC).isoformat(),
+            "prs": [
+                {"number": pr.number, "title": pr.title, "body": pr.body}
+                for pr in prs
+            ],
+        }
+        self._save(data)
+
+    def _load(self) -> dict:
+        """Load cache JSON from disk. Returns {} on missing or corrupt file."""
+        try:
+            return json.loads(self.path.read_text())
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return {}
+
+    def _save(self, data: dict) -> None:
+        """Write cache JSON to disk atomically (write tmp → rename)."""
+        dir_ = self.path.parent
+        fd, tmp_path = tempfile.mkstemp(dir=dir_, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f, indent=2)
+            os.replace(tmp_path, self.path)
+        except Exception:
+            # Clean up temp file on failure
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def _is_expired(self, entry: dict) -> bool:
+        """Return True if entry's cached_at is >30 days ago."""
+        try:
+            cached_at = datetime.fromisoformat(entry["cached_at"])
+            return datetime.now(UTC) - cached_at > _TTL
+        except (KeyError, ValueError, TypeError):
+            return True

--- a/src/why/cache.py
+++ b/src/why/cache.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 from why.prompts import PRMetadata
 
@@ -59,14 +60,15 @@ class PRCache:
         }
         self._save(data)
 
-    def _load(self) -> dict:
+    def _load(self) -> dict[str, Any]:
         """Load cache JSON from disk. Returns {} on missing or corrupt file."""
         try:
-            return json.loads(self.path.read_text())
+            result: dict[str, Any] = json.loads(self.path.read_text())
+            return result
         except (FileNotFoundError, json.JSONDecodeError, OSError):
             return {}
 
-    def _save(self, data: dict) -> None:
+    def _save(self, data: dict[str, Any]) -> None:
         """Write cache JSON to disk atomically (write tmp → rename)."""
         dir_ = self.path.parent
         fd, tmp_path = tempfile.mkstemp(dir=dir_, suffix=".tmp")
@@ -79,7 +81,7 @@ class PRCache:
                 os.unlink(tmp_path)
             raise
 
-    def _is_expired(self, entry: dict) -> bool:
+    def _is_expired(self, entry: dict[str, Any]) -> bool:
         """Return True if entry's cached_at is >30 days ago."""
         try:
             cached_at = datetime.fromisoformat(entry["cached_at"])

--- a/src/why/cli.py
+++ b/src/why/cli.py
@@ -119,7 +119,8 @@ def main(
                 slug_owner = parts[-2]
                 slug_repo = parts[-1].removesuffix(".git")
                 # Guard against path traversal: reject slugs with ".." or path separators
-                if ".." not in slug_owner and ".." not in slug_repo and "/" not in slug_owner and "/" not in slug_repo:
+                safe = all(".." not in s and "/" not in s for s in (slug_owner, slug_repo))
+                if safe:
                     repo_slug = f"{slug_owner}__{slug_repo}"
                     pr_cache = PRCache(repo_slug)
 

--- a/src/why/cli.py
+++ b/src/why/cli.py
@@ -6,11 +6,13 @@ from pathlib import Path
 import click
 
 from why import __version__
+from why.cache import PRCache
 from why.git import GitError
+from why.github import GitHubClient, detect_github_token
 from why.llm import LLMClient, LLMError
 from why.render import render_output
 from why.symbols import SymbolNotFoundError
-from why.synth import synthesize_why
+from why.synth import _get_repo_url, synthesize_why
 from why.target import TargetError, parse_target
 
 # \b is a Click magic marker that disables paragraph re-wrapping for this block,
@@ -71,6 +73,12 @@ ARGUMENTS:
     type=int,
     help="Hard cap on the number of commits sent to the LLM (newest first).",
 )
+@click.option(
+    "--no-cache",
+    is_flag=True,
+    default=False,
+    help="Disable local PR metadata cache and fetch fresh from GitHub.",
+)
 def main(
     target_spec: str,
     extra: str | None,
@@ -80,6 +88,7 @@ def main(
     brief: bool,
     deep: bool,
     max_commits: int | None,
+    no_cache: bool,
 ) -> None:
     """Explain why code is the way it is via git history and LLM synthesis."""
     cwd = Path.cwd()
@@ -96,10 +105,34 @@ def main(
         click.echo(f"Error: {exc}", err=True)
         sys.exit(1)
 
+    # Detect GitHub remote and initialize PR client when available.
+    repo_url = _get_repo_url(cwd)
+    gh_client: GitHubClient | None = None
+    pr_cache: PRCache | None = None
+    if repo_url is not None and "github.com" in repo_url:
+        token = detect_github_token()
+        gh_client = GitHubClient(repo_url, token)
+        if not no_cache:
+            # Derive repo_slug from URL: "https://github.com/owner/repo" → "owner__repo"
+            parts = repo_url.rstrip("/").split("/")
+            if len(parts) >= 2:
+                slug_owner = parts[-2]
+                slug_repo = parts[-1].removesuffix(".git")
+                # Guard against path traversal: reject slugs with ".." or path separators
+                if ".." not in slug_owner and ".." not in slug_repo and "/" not in slug_owner and "/" not in slug_repo:
+                    repo_slug = f"{slug_owner}__{slug_repo}"
+                    pr_cache = PRCache(repo_slug)
+
     try:
         llm = LLMClient(model)
         output = synthesize_why(
-            target, cwd, llm, two_pass=verify, brief=brief, deep=deep, max_commits=max_commits
+            target, cwd, llm,
+            gh=gh_client,
+            pr_cache=pr_cache,
+            two_pass=verify,
+            brief=brief,
+            deep=deep,
+            max_commits=max_commits,
         )
     except (LLMError, GitError, SymbolNotFoundError) as exc:
         click.echo(f"Error: {exc}", err=True)

--- a/src/why/github.py
+++ b/src/why/github.py
@@ -1,0 +1,103 @@
+"""GitHub REST API client for PR metadata lookup."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from why.prompts import PRMetadata
+
+_API_BASE = "https://api.github.com"
+_TIMEOUT = 10
+
+
+class GitHubError(Exception):
+    """Base exception for GitHub API failures."""
+
+
+class GitHubAuthError(GitHubError):
+    """Raised when GitHub returns 401 or 403."""
+
+
+class GitHubClient:
+    def __init__(self, repo_url: str, token: str | None = None) -> None:
+        """
+        repo_url: normalized https://github.com/owner/repo URL
+        token: GitHub personal access token or None for unauthenticated
+        """
+        parsed = urllib.parse.urlparse(repo_url)
+        # path is like /owner/repo or /owner/repo.git
+        parts = parsed.path.strip("/").split("/")
+        self._owner = parts[0]
+        self._repo = parts[1].removesuffix(".git") if len(parts) > 1 else parts[0]
+        self._token = token
+
+    def get_prs_for_commit(self, sha: str) -> list[PRMetadata]:
+        """
+        Return PRs associated with sha. Returns [] on any API failure (404, timeout, etc).
+        Raises GitHubAuthError on 401/403.
+        """
+        try:
+            return self._fetch_prs(sha)
+        except GitHubAuthError:
+            raise
+        except Exception:
+            return []
+
+    def _fetch_prs(self, sha: str) -> list[PRMetadata]:
+        """Raw API call to /repos/{owner}/{repo}/commits/{sha}/pulls"""
+        url = f"{_API_BASE}/repos/{self._owner}/{self._repo}/commits/{sha}/pulls"
+        req = urllib.request.Request(url)
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if self._token:
+            req.add_header("Authorization", f"Bearer {self._token}")
+
+        try:
+            with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+                data = json.loads(resp.read())
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise GitHubAuthError(f"GitHub auth failed: {exc.code}") from exc
+            raise
+
+        return [
+            PRMetadata(
+                number=pr["number"],
+                title=pr["title"],
+                body=pr["body"] or "",
+            )
+            for pr in data
+        ]
+
+
+def detect_github_token() -> str | None:
+    """
+    Discover GitHub token:
+    1. GITHUB_TOKEN env var
+    2. subprocess: gh auth token (silent on failure)
+    3. None (unauthenticated)
+    """
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token
+
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            token = result.stdout.strip()
+            if token and "\n" not in token and "\r" not in token and " " not in token:
+                return token
+    except Exception:
+        pass
+
+    return None

--- a/src/why/prompts.py
+++ b/src/why/prompts.py
@@ -187,9 +187,10 @@ WHY_SYSTEM_PROMPT: str = build_system_prompt()  # no-URL fallback
 
 
 class PRMetadata(NamedTuple):
-    """PR number and body text sourced from VCS metadata."""
+    """PR number, title, and body text sourced from VCS metadata."""
 
     number: int
+    title: str
     body: str
 
 
@@ -200,6 +201,7 @@ class CommitWithPR:
     commit: Commit
     pr_body: str | None = None
     pr_number: int | None = None
+    pr_title: str | None = None
     diff: str = ""  # patch text from get_commit_diff(); empty = not yet fetched
 
 
@@ -265,10 +267,24 @@ def _render_commit(cwpr: CommitWithPR) -> str:
     # Escape triple backticks in diff content to prevent premature fence closure
     safe_diff = diff_text.replace("```", "\\`\\`\\`")
 
-    # Escape triple backticks in pr_body to prevent premature text-fence closure.
-    # Both None and "" fall through to "N/A".
-    safe_pr_body = cwpr.pr_body.replace("```", "\\`\\`\\`") if cwpr.pr_body else None
-    pr_section = f"```text\n{safe_pr_body}\n```" if safe_pr_body else "N/A"
+    # Build PR section only when a PR is present; omit entirely when absent.
+    pr_section = ""
+    if cwpr.pr_number is not None:
+        safe_title = (cwpr.pr_title or "").replace("\n", " ").replace("\r", "")
+        # Escape triple backticks in pr_body to prevent premature text-fence closure.
+        raw_body = cwpr.pr_body or ""
+        safe_pr_body = raw_body.replace("```", "\\`\\`\\`")
+        # Truncate body at 1000 chars to keep prompt size bounded.
+        if len(safe_pr_body) > 1000:
+            safe_pr_body = safe_pr_body[:1000] + " …"
+        pr_section = (
+            f"\n"
+            f"**PR #{cwpr.pr_number}:** `{safe_title}`\n"
+            f"\n"
+            f"```text\n"
+            f"{safe_pr_body}\n"
+            f"```\n"
+        )
 
     return (
         f'### `{commit.short_sha}` — "{safe_subject}" · {date_str} · {safe_author}\n'
@@ -278,10 +294,7 @@ def _render_commit(cwpr: CommitWithPR) -> str:
         f"```diff\n"
         f"{safe_diff}\n"
         f"```\n"
-        f"\n"
-        f"**PR Body:**\n"
-        f"\n"
-        f"{pr_section}\n"
+        f"{pr_section}"
         f"\n"
         f"---"
     )

--- a/src/why/synth.py
+++ b/src/why/synth.py
@@ -9,9 +9,11 @@ from pathlib import Path
 
 import click
 
+from why.cache import PRCache
 from why.citations import validate_citations
 from why.diff import get_commit_diff
 from why.git import GitError
+from why.github import GitHubAuthError, GitHubClient
 from why.history import get_file_history, get_line_history
 from why.llm import LLMClient, Message
 from why.prompts import (
@@ -144,6 +146,8 @@ def synthesize_why(
     repo: Path,
     llm: LLMClient,
     prs: dict[str, PRMetadata] | None = None,
+    gh: GitHubClient | None = None,
+    pr_cache: PRCache | None = None,
     strict: bool = False,
     two_pass: bool = False,
     brief: bool = False,
@@ -192,6 +196,34 @@ def synthesize_why(
     # Sort oldest-first so the LLM sees chronological order regardless of path.
     key_commits = sorted(key_commits, key=lambda c: c.date)
 
+    # Fetch PR metadata via GitHub client when available.
+    # Explicit prs dict takes precedence (backward-compatible for tests and direct callers).
+    resolved_prs: dict[str, PRMetadata] = dict(prs) if prs else {}
+    if gh is not None and not resolved_prs:
+        for c in key_commits:
+            # Cache-first: check cache before hitting API
+            cached = pr_cache.get(c.sha) if pr_cache is not None else None
+            if cached is not None:
+                if cached:
+                    resolved_prs[c.sha] = cached[0]
+                continue
+            # Cache miss — fetch from GitHub
+            try:
+                fetched = gh.get_prs_for_commit(c.sha)
+            except GitHubAuthError:
+                click.echo(
+                    "⚠  GitHub PR data unavailable — proceeding without PR context",
+                    err=True,
+                )
+                break
+            if pr_cache is not None:
+                try:
+                    pr_cache.set(c.sha, fetched)
+                except OSError as exc:
+                    _log.warning("could not write PR cache for %s: %s", c.sha[:12], exc)
+            if fetched:
+                resolved_prs[c.sha] = fetched[0]
+
     # Fetch per-commit diffs; swallow GitError on individual commits rather than
     # aborting the whole call.
     diffs: dict[str, str] = {}
@@ -206,12 +238,13 @@ def synthesize_why(
 
     commits_with_prs = []
     for c in key_commits:
-        meta = prs.get(c.sha)
+        meta = resolved_prs.get(c.sha)
         commits_with_prs.append(
             CommitWithPR(
                 commit=c,
                 pr_body=meta.body if meta else None,
                 pr_number=meta.number if meta else None,
+                pr_title=meta.title if meta else None,
                 diff=diffs[c.sha],
             )
         )

--- a/tests/fixtures/prompts/why_prompt_golden.txt
+++ b/tests/fixtures/prompts/why_prompt_golden.txt
@@ -29,7 +29,7 @@ The git history for this region is sparse (1 commit(s)). In addition to explaini
 (no diff available)
 ```
 
-**PR Body:**
+**PR #42:** `Fix null check`
 
 ```text
 Fixes #99: adds null check
@@ -44,5 +44,5 @@ Fixes #99: adds null check
 (Copy SHAs and dates verbatim into the timeline — do not alter them)
 
 ```text
-2026-01-15  abc1234  fix: handle null token in auth check
+2026-01-15  abc1234  fix: handle null token in auth check  [PR #42]
 ```

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,168 @@
+"""Tests for src/why/cache.py — SHA-keyed PR metadata cache.
+
+Written BEFORE the implementation (TDD red phase).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from why.cache import PRCache, xdg_cache_dir
+from why.prompts import PRMetadata
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_prs() -> list[PRMetadata]:
+    return [PRMetadata(number=42, title="Fix bug", body="body text")]
+
+
+def _patch_xdg(monkeypatch, tmp_path: Path) -> None:
+    """Override xdg_cache_dir so the cache writes under tmp_path."""
+    monkeypatch.setattr("why.cache.xdg_cache_dir", lambda: tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# xdg_cache_dir
+# ---------------------------------------------------------------------------
+
+class TestXdgCacheDir:
+    def test_xdg_cache_dir_from_env(self, monkeypatch):
+        monkeypatch.setenv("XDG_CACHE_HOME", "/tmp/test")
+        assert xdg_cache_dir() == Path("/tmp/test")
+
+    def test_xdg_cache_dir_default(self, monkeypatch):
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        assert xdg_cache_dir() == Path.home() / ".cache"
+
+
+# ---------------------------------------------------------------------------
+# PRCache.path
+# ---------------------------------------------------------------------------
+
+class TestPRCachePath:
+    def test_cache_path_uses_repo_slug(self, monkeypatch, tmp_path):
+        _patch_xdg(monkeypatch, tmp_path)
+        cache = PRCache("owner__repo")
+        assert cache.path == tmp_path / "why" / "owner__repo.json"
+
+
+# ---------------------------------------------------------------------------
+# PRCache.get — misses
+# ---------------------------------------------------------------------------
+
+class TestPRCacheMiss:
+    def test_cache_miss_returns_none(self, monkeypatch, tmp_path):
+        _patch_xdg(monkeypatch, tmp_path)
+        cache = PRCache("owner__repo")
+        assert cache.get("deadbeef") is None
+
+    def test_cache_missing_file_returns_none(self, monkeypatch, tmp_path):
+        _patch_xdg(monkeypatch, tmp_path)
+        cache = PRCache("owner__repo")
+        # Explicitly ensure the file does not exist.
+        assert not cache.path.exists()
+        assert cache.get("deadbeef") is None
+
+    def test_cache_corrupt_file_returns_none(self, monkeypatch, tmp_path):
+        _patch_xdg(monkeypatch, tmp_path)
+        cache = PRCache("owner__repo")
+        cache.path.parent.mkdir(parents=True, exist_ok=True)
+        cache.path.write_text("not valid json{{{{")
+        assert cache.get("deadbeef") is None
+
+
+# ---------------------------------------------------------------------------
+# PRCache.set / get — round-trips
+# ---------------------------------------------------------------------------
+
+class TestPRCacheRoundTrip:
+    def test_cache_set_then_get(self, monkeypatch, tmp_path):
+        _patch_xdg(monkeypatch, tmp_path)
+        cache = PRCache("owner__repo")
+        prs = _make_prs()
+        cache.set("abc123", prs)
+        result = cache.get("abc123")
+        assert result == prs
+
+    def test_cache_stores_title(self, monkeypatch, tmp_path):
+        _patch_xdg(monkeypatch, tmp_path)
+        cache = PRCache("owner__repo")
+        prs = [PRMetadata(number=7, title="My feature PR", body="desc")]
+        cache.set("sha1", prs)
+        result = cache.get("sha1")
+        assert result is not None
+        assert result[0].title == "My feature PR"
+
+    def test_cache_empty_pr_list(self, monkeypatch, tmp_path):
+        _patch_xdg(monkeypatch, tmp_path)
+        cache = PRCache("owner__repo")
+        cache.set("sha_empty", [])
+        result = cache.get("sha_empty")
+        # Must return [] (not None) — cached empty list is a valid hit
+        assert result == []
+
+    def test_cache_creates_parent_dirs(self, monkeypatch, tmp_path):
+        _patch_xdg(monkeypatch, tmp_path)
+        cache = PRCache("owner__repo")
+        # Parent dirs do not exist yet
+        assert not cache.path.parent.exists()
+        cache.set("sha_dirs", _make_prs())
+        assert cache.path.parent.exists()
+        assert cache.path.exists()
+
+
+# ---------------------------------------------------------------------------
+# TTL
+# ---------------------------------------------------------------------------
+
+class TestPRCacheTTL:
+    def _write_raw_entry(self, cache: PRCache, sha: str, cached_at: datetime) -> None:
+        """Write a raw cache entry with a custom timestamp for TTL testing."""
+        data = cache._load()
+        data[sha] = {
+            "cached_at": cached_at.isoformat(),
+            "prs": [{"number": 1, "title": "t", "body": "b"}],
+        }
+        cache._save(data)
+
+    def test_cache_hit_not_expired(self, monkeypatch, tmp_path):
+        _patch_xdg(monkeypatch, tmp_path)
+        cache = PRCache("owner__repo")
+        cache.path.parent.mkdir(parents=True, exist_ok=True)
+        one_day_ago = datetime.now(UTC) - timedelta(days=1)
+        self._write_raw_entry(cache, "fresh_sha", one_day_ago)
+        result = cache.get("fresh_sha")
+        assert result is not None
+        assert result[0].number == 1
+
+    def test_cache_expired_returns_none(self, monkeypatch, tmp_path):
+        _patch_xdg(monkeypatch, tmp_path)
+        cache = PRCache("owner__repo")
+        cache.path.parent.mkdir(parents=True, exist_ok=True)
+        thirty_one_days_ago = datetime.now(UTC) - timedelta(days=31)
+        self._write_raw_entry(cache, "stale_sha", thirty_one_days_ago)
+        result = cache.get("stale_sha")
+        assert result is None
+
+    def test_cache_naive_datetime_returns_none(self, monkeypatch, tmp_path):
+        """A cache entry with a naive (no tzinfo) datetime string must return None, not crash."""
+        _patch_xdg(monkeypatch, tmp_path)
+        cache = PRCache("owner__repo")
+        cache.path.parent.mkdir(parents=True, exist_ok=True)
+        # Write a naive ISO datetime string (no +00:00 suffix) directly into the cache file.
+        data = {
+            "naive_sha": {
+                "cached_at": "2025-01-01T00:00:00",  # naive — no timezone info
+                "prs": [{"number": 1, "title": "t", "body": "b"}],
+            }
+        }
+        cache._save(data)
+        # Must return None (treat as expired/invalid) without raising TypeError
+        assert cache.get("naive_sha") is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,15 +5,11 @@ Written BEFORE the implementation (TDD red phase).
 
 from __future__ import annotations
 
-import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-import pytest
-
 from why.cache import PRCache, xdg_cache_dir
 from why.prompts import PRMetadata
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -678,3 +678,45 @@ def test_max_commits_negative_exits_nonzero(existing_file: Path) -> None:
         result = CliRunner().invoke(main, ["--max-commits", "-1", "--deep", str(existing_file)])
     assert result.exit_code != 0
     assert "must be >= 1" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --no-cache flag tests (Stride 4)
+# ---------------------------------------------------------------------------
+
+
+def test_no_cache_flag_accepted(existing_file: Path) -> None:
+    """--no-cache is a valid flag — exit code 0."""
+    with (
+        patch("why.cli.Path") as mock_path_cls,
+        patch("why.cli.LLMClient") as mock_llm_cls,
+        patch("why.cli.synthesize_why", return_value="explanation"),
+    ):
+        mock_llm_cls.return_value = MagicMock()
+        mock_path_cls.cwd.return_value = existing_file.parent
+        result = CliRunner().invoke(main, ["--no-cache", str(existing_file)])
+    assert result.exit_code == 0, result.output
+
+
+def test_no_cache_flag_help_text() -> None:
+    """--help output includes 'no-cache'."""
+    result = CliRunner().invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "no-cache" in result.output
+
+
+def test_no_cache_flag_passes_pr_cache_none(existing_file: Path) -> None:
+    """When --no-cache is passed, synthesize_why is called with pr_cache=None."""
+    with (
+        patch("why.cli.Path") as mock_path_cls,
+        patch("why.cli.LLMClient") as mock_llm_cls,
+        patch("why.cli.synthesize_why", return_value="explanation") as mock_synth,
+        patch("why.cli._get_repo_url", return_value="https://github.com/owner/repo"),
+        patch("why.cli.detect_github_token", return_value=None),
+    ):
+        mock_llm_cls.return_value = MagicMock()
+        mock_path_cls.cwd.return_value = existing_file.parent
+        result = CliRunner().invoke(main, ["--no-cache", str(existing_file)])
+    assert result.exit_code == 0, result.output
+    _, kwargs = mock_synth.call_args
+    assert kwargs.get("pr_cache") is None

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -5,7 +5,6 @@ Written BEFORE the implementation (TDD red phase).
 
 from __future__ import annotations
 
-import io
 import json
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
@@ -14,7 +13,6 @@ import pytest
 
 from why.github import GitHubAuthError, GitHubClient, detect_github_token
 from why.prompts import PRMetadata
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,161 @@
+"""Tests for src/why/github.py — GitHubClient and detect_github_token.
+
+Written BEFORE the implementation (TDD red phase).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from why.github import GitHubAuthError, GitHubClient, detect_github_token
+from why.prompts import PRMetadata
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_urlopen_mock(payload: list[dict]) -> MagicMock:
+    """Return a mock that urlopen returns a file-like object with JSON payload."""
+    response_body = json.dumps(payload).encode()
+    mock_response = MagicMock()
+    mock_response.read.return_value = response_body
+    mock_response.__enter__ = lambda s: s
+    mock_response.__exit__ = MagicMock(return_value=False)
+    mock_urlopen = MagicMock(return_value=mock_response)
+    return mock_urlopen
+
+
+# ---------------------------------------------------------------------------
+# get_prs_for_commit — happy path
+# ---------------------------------------------------------------------------
+
+class TestGetPrsForCommit:
+    def _client(self) -> GitHubClient:
+        return GitHubClient("https://github.com/owner/repo")
+
+    def test_get_prs_for_commit_empty(self):
+        mock_urlopen = _make_urlopen_mock([])
+        with patch("urllib.request.urlopen", mock_urlopen):
+            result = self._client().get_prs_for_commit("abc123")
+        assert result == []
+
+    def test_get_prs_for_commit_single_pr(self):
+        payload = [{"number": 42, "title": "Fix bug", "body": "body text"}]
+        mock_urlopen = _make_urlopen_mock(payload)
+        with patch("urllib.request.urlopen", mock_urlopen):
+            result = self._client().get_prs_for_commit("abc123")
+        assert result == [PRMetadata(42, "Fix bug", "body text")]
+
+    def test_get_prs_for_commit_multiple_prs(self):
+        payload = [
+            {"number": 1, "title": "First", "body": "body one"},
+            {"number": 2, "title": "Second", "body": "body two"},
+        ]
+        mock_urlopen = _make_urlopen_mock(payload)
+        with patch("urllib.request.urlopen", mock_urlopen):
+            result = self._client().get_prs_for_commit("abc123")
+        assert result == [
+            PRMetadata(1, "First", "body one"),
+            PRMetadata(2, "Second", "body two"),
+        ]
+
+    def test_get_prs_for_commit_null_body(self):
+        payload = [{"number": 7, "title": "No body PR", "body": None}]
+        mock_urlopen = _make_urlopen_mock(payload)
+        with patch("urllib.request.urlopen", mock_urlopen):
+            result = self._client().get_prs_for_commit("abc123")
+        assert result == [PRMetadata(7, "No body PR", "")]
+
+
+# ---------------------------------------------------------------------------
+# get_prs_for_commit — error handling
+# ---------------------------------------------------------------------------
+
+class TestGetPrsForCommitErrors:
+    def _client(self) -> GitHubClient:
+        return GitHubClient("https://github.com/owner/repo")
+
+    def test_get_prs_for_commit_404_returns_empty(self):
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = HTTPError(
+                url="https://api.github.com/...", code=404,
+                msg="Not Found", hdrs=None, fp=None
+            )
+            result = self._client().get_prs_for_commit("abc123")
+        assert result == []
+
+    def test_get_prs_for_commit_401_raises_auth_error(self):
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = HTTPError(
+                url="https://api.github.com/...", code=401,
+                msg="Unauthorized", hdrs=None, fp=None
+            )
+            with pytest.raises(GitHubAuthError):
+                self._client().get_prs_for_commit("abc123")
+
+    def test_get_prs_for_commit_403_raises_auth_error(self):
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = HTTPError(
+                url="https://api.github.com/...", code=403,
+                msg="Forbidden", hdrs=None, fp=None
+            )
+            with pytest.raises(GitHubAuthError):
+                self._client().get_prs_for_commit("abc123")
+
+    def test_get_prs_for_commit_network_error_returns_empty(self):
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = URLError("Connection refused")
+            result = self._client().get_prs_for_commit("abc123")
+        assert result == []
+
+    def test_get_prs_for_commit_timeout_returns_empty(self):
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = TimeoutError("timed out")
+            result = self._client().get_prs_for_commit("abc123")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# detect_github_token
+# ---------------------------------------------------------------------------
+
+class TestDetectGithubToken:
+    def test_detect_github_token_from_env(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "abc123")
+        assert detect_github_token() == "abc123"
+
+    def test_detect_github_token_none_when_missing(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            result = detect_github_token()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# URL parsing
+# ---------------------------------------------------------------------------
+
+class TestGithubClientInit:
+    def test_github_client_parses_owner_repo(self):
+        client = GitHubClient("https://github.com/owner/repo")
+        assert client._owner == "owner"
+        assert client._repo == "repo"
+
+    def test_github_client_strips_dot_git(self):
+        client = GitHubClient("https://github.com/owner/repo.git")
+        assert client._repo == "repo"
+
+    def test_github_client_stores_token(self):
+        client = GitHubClient("https://github.com/owner/repo", token="mytoken")
+        assert client._token == "mytoken"
+
+    def test_github_client_no_token_is_none(self):
+        client = GitHubClient("https://github.com/owner/repo")
+        assert client._token is None

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -131,7 +131,10 @@ def test_commit_date_format() -> None:
 
 def test_pr_body_present() -> None:
     """When pr_number and pr_body are set, the content string must appear verbatim."""
-    commits = [CommitWithPR(commit=FIXED_COMMIT, pr_number=42, pr_title="Fix null check", pr_body="Fixes #99: adds null check")]
+    commits = [
+        CommitWithPR(commit=FIXED_COMMIT, pr_number=42, pr_title="Fix null check",
+                     pr_body="Fixes #99: adds null check")
+    ]
     result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
     assert "Fixes #99: adds null check" in result[0].content
 
@@ -182,7 +185,10 @@ def test_system_prompt_not_empty() -> None:
 
 def test_golden_file(update_goldens: bool) -> None:
     """Content must match the golden fixture exactly."""
-    commits = [CommitWithPR(commit=FIXED_COMMIT, pr_number=42, pr_title="Fix null check", pr_body="Fixes #99: adds null check")]
+    commits = [
+        CommitWithPR(commit=FIXED_COMMIT, pr_number=42, pr_title="Fix null check",
+                     pr_body="Fixes #99: adds null check")
+    ]
     result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
     content = result[0].content
     golden = Path(__file__).parent / "fixtures" / "prompts" / "why_prompt_golden.txt"
@@ -281,7 +287,7 @@ def test_pr_body_is_fenced() -> None:
 
 
 def test_pr_body_empty_string() -> None:
-    """When pr_number is present but pr_body is empty, the PR section still renders (with empty fence)."""
+    """When pr_number is present but pr_body is empty, the PR section still renders."""
     cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_number=1, pr_title="Empty body PR", pr_body="")
     result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [cwpr])
     # PR section should be present since pr_number is set

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -17,6 +17,7 @@ from why.prompts import (
     WHY_SYSTEM_PROMPT,
     CommitWithPR,
     PRMetadata,
+    _render_commit,
     build_grounding_prompt,
     build_system_prompt,
     build_why_prompt,
@@ -129,17 +130,18 @@ def test_commit_date_format() -> None:
 
 
 def test_pr_body_present() -> None:
-    """When pr_body is set, the content string must appear verbatim."""
-    commits = [CommitWithPR(commit=FIXED_COMMIT, pr_body="Fixes #99: adds null check")]
+    """When pr_number and pr_body are set, the content string must appear verbatim."""
+    commits = [CommitWithPR(commit=FIXED_COMMIT, pr_number=42, pr_title="Fix null check", pr_body="Fixes #99: adds null check")]
     result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
     assert "Fixes #99: adds null check" in result[0].content
 
 
 def test_pr_body_absent() -> None:
-    """When pr_body is None, the PR Body section must show 'N/A'."""
+    """When pr_number is None, the PR section is omitted entirely (no 'N/A')."""
     commits = [CommitWithPR(commit=FIXED_COMMIT, pr_body=None)]
     result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
-    assert "N/A" in result[0].content
+    assert "N/A" not in result[0].content
+    assert "PR Body" not in result[0].content
 
 
 # ---------------------------------------------------------------------------
@@ -180,7 +182,7 @@ def test_system_prompt_not_empty() -> None:
 
 def test_golden_file(update_goldens: bool) -> None:
     """Content must match the golden fixture exactly."""
-    commits = [CommitWithPR(commit=FIXED_COMMIT, pr_body="Fixes #99: adds null check")]
+    commits = [CommitWithPR(commit=FIXED_COMMIT, pr_number=42, pr_title="Fix null check", pr_body="Fixes #99: adds null check")]
     result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, commits)
     content = result[0].content
     golden = Path(__file__).parent / "fixtures" / "prompts" / "why_prompt_golden.txt"
@@ -263,6 +265,8 @@ def test_pr_body_is_fenced() -> None:
     """PR body must be wrapped in a ```text fence to prevent Markdown injection."""
     cwpr = CommitWithPR(
         commit=FIXED_COMMIT,
+        pr_number=1,
+        pr_title="Injection test",
         pr_body="## Injected Heading\nsome content",
     )
     result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [cwpr])
@@ -277,10 +281,12 @@ def test_pr_body_is_fenced() -> None:
 
 
 def test_pr_body_empty_string() -> None:
-    """An empty string pr_body must render as 'N/A', same as None."""
-    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_body="")
+    """When pr_number is present but pr_body is empty, the PR section still renders (with empty fence)."""
+    cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_number=1, pr_title="Empty body PR", pr_body="")
     result = build_why_prompt(FIXED_TARGET, FIXED_CURRENT_CODE, [cwpr])
-    assert "N/A" in result[0].content
+    # PR section should be present since pr_number is set
+    assert "PR #1:" in result[0].content
+    assert "N/A" not in result[0].content
 
 
 # ---------------------------------------------------------------------------
@@ -572,25 +578,66 @@ def test_build_why_prompt_brief_section_header() -> None:
 
 
 def test_prmetadata_construction() -> None:
-    """PRMetadata can be constructed with number and body fields."""
-    meta = PRMetadata(number=42, body="Fixes #99: adds null check")
+    """PRMetadata can be constructed with number, title, and body fields."""
+    meta = PRMetadata(number=42, title="Fix null check", body="Fixes #99: adds null check")
     assert meta.number == 42
+    assert meta.title == "Fix null check"
     assert meta.body == "Fixes #99: adds null check"
 
 
 def test_prmetadata_fields_accessible_by_name() -> None:
     """PRMetadata fields are accessible by attribute name."""
-    meta = PRMetadata(number=7, body="some body text")
+    meta = PRMetadata(number=7, title="Some feature", body="some body text")
     assert meta.number == 7
+    assert meta.title == "Some feature"
     assert meta.body == "some body text"
 
 
 def test_prmetadata_is_namedtuple() -> None:
     """PRMetadata is a NamedTuple and supports tuple unpacking."""
-    meta = PRMetadata(number=1, body="test")
-    number, body = meta
+    meta = PRMetadata(number=1, title="A title", body="test")
+    number, title, body = meta
     assert number == 1
+    assert title == "A title"
     assert body == "test"
+
+
+def test_render_commit_with_pr_shows_title_and_body() -> None:
+    """When PR is present, rendered output shows PR number and title as bold header."""
+    cwpr = CommitWithPR(
+        commit=FIXED_COMMIT,
+        pr_number=42,
+        pr_title="Fix the title",
+        pr_body="This PR fixes things.",
+    )
+    result = _render_commit(cwpr)
+    assert "PR #42:" in result
+    assert "Fix the title" in result
+
+
+def test_render_commit_with_pr_truncates_body_at_1000() -> None:
+    """Body longer than 1000 chars is truncated with ' …' suffix."""
+    long_body = "x" * 1100
+    cwpr = CommitWithPR(
+        commit=FIXED_COMMIT,
+        pr_number=5,
+        pr_title="Long PR",
+        pr_body=long_body,
+    )
+    result = _render_commit(cwpr)
+    assert " …" in result
+    # The truncated body should be 1000 chars + " …"
+    assert "x" * 1000 + " …" in result
+    # The full long body must not appear
+    assert "x" * 1100 not in result
+
+
+def test_render_commit_without_pr_omits_pr_section() -> None:
+    """When no PR is associated, the PR section is entirely omitted (no 'PR Body' or 'N/A')."""
+    cwpr = CommitWithPR(commit=FIXED_COMMIT)
+    result = _render_commit(cwpr)
+    assert "PR Body" not in result
+    assert "N/A" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -624,3 +671,24 @@ def test_commitwithpr_is_still_frozen() -> None:
     cwpr = CommitWithPR(commit=FIXED_COMMIT, pr_number=1)
     with pytest.raises(dataclasses.FrozenInstanceError):
         cwpr.pr_number = 2  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Markdown injection — PR title bold-marker sanitization
+# ---------------------------------------------------------------------------
+
+
+def test_render_commit_pr_title_with_bold_markers() -> None:
+    """A PR title containing '**' must be wrapped in backticks, not injected as raw Markdown."""
+    cwpr = CommitWithPR(
+        commit=FIXED_COMMIT,
+        pr_number=1,
+        pr_title="foo** injected **bar",
+        pr_body="body",
+    )
+    result = _render_commit(cwpr)
+    # The title must appear wrapped in backtick delimiters
+    assert "`foo** injected **bar`" in result
+    # The title must NOT appear as a raw unquoted bold-marker sequence that would
+    # break the surrounding **PR #N:** bold span.
+    assert "**PR #1: foo**" not in result

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -336,7 +336,9 @@ class TestSynthesizeWhyPRBodyWiring:
         sha_c = "ccc0" * 10
         commits = [_make_commit(sha_a), _make_commit(sha_b), _make_commit(sha_c)]
         # Only sha_a has a PR; sha_b and sha_c do not
-        prs: dict[str, PRMetadata] = {sha_a: PRMetadata(number=42, title="PR title for A", body="PR body for A")}
+        prs: dict[str, PRMetadata] = {
+            sha_a: PRMetadata(number=42, title="PR title for A", body="PR body for A")
+        }
         f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
         target = Target(file=f)
         llm = MagicMock()
@@ -680,7 +682,10 @@ class TestRenderCommitPRBodyEscaping:
             body="",
             parents=(),
         )
-        cwpr = CommitWithPR(commit=commit, pr_number=1, pr_title="Backtick test", pr_body="look at this ```code block```")
+        cwpr = CommitWithPR(
+            commit=commit, pr_number=1, pr_title="Backtick test",
+            pr_body="look at this ```code block```",
+        )
         target = Target(file=Path("src/foo.py"))
 
         result = build_why_prompt(target, "x = 1", [cwpr])
@@ -1398,7 +1403,6 @@ class TestSynthesizeWhyGitHubPRFetching:
         from why.prompts import PRMetadata
 
         commits, _f, target = self._make_setup(tmp_path, n=1)
-        sha = commits[0].sha
         mock_gh = MagicMock(spec=GitHubClient)
         mock_gh.get_prs_for_commit.return_value = [PRMetadata(42, "Fix bug", "pr body")]
 
@@ -1433,7 +1437,6 @@ class TestSynthesizeWhyGitHubPRFetching:
         from why.prompts import PRMetadata
 
         commits, _f, target = self._make_setup(tmp_path, n=1)
-        sha = commits[0].sha
         mock_gh = MagicMock(spec=GitHubClient)
         mock_cache = MagicMock(spec=PRCache)
         mock_cache.get.return_value = [PRMetadata(7, "Cached PR", "cached body")]

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -336,7 +336,7 @@ class TestSynthesizeWhyPRBodyWiring:
         sha_c = "ccc0" * 10
         commits = [_make_commit(sha_a), _make_commit(sha_b), _make_commit(sha_c)]
         # Only sha_a has a PR; sha_b and sha_c do not
-        prs: dict[str, PRMetadata] = {sha_a: PRMetadata(number=42, body="PR body for A")}
+        prs: dict[str, PRMetadata] = {sha_a: PRMetadata(number=42, title="PR title for A", body="PR body for A")}
         f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
         target = Target(file=f)
         llm = MagicMock()
@@ -374,7 +374,7 @@ class TestSynthesizeWhyPRBodyWiring:
         sha_a = "aaa1" * 10
         sha_b = "bbb1" * 10
         commits = [_make_commit(sha_a), _make_commit(sha_b)]
-        prs: dict[str, PRMetadata] = {sha_a: PRMetadata(number=99, body="body A")}
+        prs: dict[str, PRMetadata] = {sha_a: PRMetadata(number=99, title="title A", body="body A")}
         f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
         target = Target(file=f)
         llm = MagicMock()
@@ -407,7 +407,7 @@ class TestSynthesizeWhyPRBodyWiring:
 
         sha_a = "aaa2" * 10
         commits = [_make_commit(sha_a)]
-        prs: dict[str, PRMetadata] = {sha_a: PRMetadata(number=77, body="body")}
+        prs: dict[str, PRMetadata] = {sha_a: PRMetadata(number=77, title="body title", body="body")}
         f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
         target = Target(file=f)
         llm = MagicMock()
@@ -444,9 +444,9 @@ class TestSynthesizeWhyPRBodyWiring:
         all_commits = [_make_commit(sha_key), _make_commit(sha_nonkey1), _make_commit(sha_nonkey2)]
         # All three SHAs have PR entries, but only sha_key is selected as a key commit
         prs: dict[str, PRMetadata] = {
-            sha_key: PRMetadata(number=10, body="key PR"),
-            sha_nonkey1: PRMetadata(number=99, body="non-key PR 1"),
-            sha_nonkey2: PRMetadata(number=100, body="non-key PR 2"),
+            sha_key: PRMetadata(number=10, title="key PR title", body="key PR"),
+            sha_nonkey1: PRMetadata(number=99, title="non-key PR title 1", body="non-key PR 1"),
+            sha_nonkey2: PRMetadata(number=100, title="non-key PR title 2", body="non-key PR 2"),
         }
         f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
         target = Target(file=f)
@@ -680,7 +680,7 @@ class TestRenderCommitPRBodyEscaping:
             body="",
             parents=(),
         )
-        cwpr = CommitWithPR(commit=commit, pr_body="look at this ```code block```")
+        cwpr = CommitWithPR(commit=commit, pr_number=1, pr_title="Backtick test", pr_body="look at this ```code block```")
         target = Target(file=Path("src/foo.py"))
 
         result = build_why_prompt(target, "x = 1", [cwpr])
@@ -1373,6 +1373,202 @@ class TestSynthesizeWhyDeepCostWarningIncludesModel:
         assert any("test-model" in msg for msg in warning_messages), (
             f"Expected model name in warning, got: {warning_messages}"
         )
+
+
+# ---------------------------------------------------------------------------
+# GitHub PR fetching tests (Stride 4)
+# ---------------------------------------------------------------------------
+
+_PATCH_CLICK = "why.synth.click"
+
+
+class TestSynthesizeWhyGitHubPRFetching:
+    """synthesize_why fetches PR metadata via GitHubClient when gh= is provided."""
+
+    def _make_setup(self, tmp_path: Path, n: int = 3):
+        commits = [_make_commit(f"ghpr{i:04d}" * 10) for i in range(n)]
+        f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
+        target = Target(file=f)
+        return commits, f, target
+
+    def test_gh_client_prs_injected_into_commits_with_pr(self, tmp_path: Path) -> None:
+        """When gh= is provided and returns a PR for a key commit SHA, that commit
+        gets pr_number and pr_title populated in CommitWithPR."""
+        from why.github import GitHubClient
+        from why.prompts import PRMetadata
+
+        commits, _f, target = self._make_setup(tmp_path, n=1)
+        sha = commits[0].sha
+        mock_gh = MagicMock(spec=GitHubClient)
+        mock_gh.get_prs_for_commit.return_value = [PRMetadata(42, "Fix bug", "pr body")]
+
+        llm = MagicMock()
+        llm.complete.return_value = "answer"
+        captured: list = []
+
+        def fake_build_prompt(t, code, cwprs, **kwargs):
+            captured.extend(cwprs)
+            return [MagicMock()]
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, side_effect=fake_build_prompt),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
+            synthesize_why(target, tmp_path, llm, gh=mock_gh)
+
+        assert len(captured) == 1
+        assert captured[0].pr_number == 42
+        assert captured[0].pr_title == "Fix bug"
+
+    def test_gh_client_cache_hit_skips_api_call(self, tmp_path: Path) -> None:
+        """When pr_cache.get(sha) returns a cached PR list, gh.get_prs_for_commit
+        is NOT called for that SHA."""
+        from why.cache import PRCache
+        from why.github import GitHubClient
+        from why.prompts import PRMetadata
+
+        commits, _f, target = self._make_setup(tmp_path, n=1)
+        sha = commits[0].sha
+        mock_gh = MagicMock(spec=GitHubClient)
+        mock_cache = MagicMock(spec=PRCache)
+        mock_cache.get.return_value = [PRMetadata(7, "Cached PR", "cached body")]
+
+        llm = MagicMock()
+        llm.complete.return_value = "answer"
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
+            synthesize_why(target, tmp_path, llm, gh=mock_gh, pr_cache=mock_cache)
+
+        mock_gh.get_prs_for_commit.assert_not_called()
+
+    def test_gh_client_cache_miss_fetches_and_stores(self, tmp_path: Path) -> None:
+        """When pr_cache.get(sha) returns None (cache miss), gh.get_prs_for_commit
+        IS called and the result is stored via pr_cache.set."""
+        from why.cache import PRCache
+        from why.github import GitHubClient
+        from why.prompts import PRMetadata
+
+        commits, _f, target = self._make_setup(tmp_path, n=1)
+        sha = commits[0].sha
+        fetched_prs = [PRMetadata(55, "Fresh PR", "fresh body")]
+        mock_gh = MagicMock(spec=GitHubClient)
+        mock_gh.get_prs_for_commit.return_value = fetched_prs
+        mock_cache = MagicMock(spec=PRCache)
+        mock_cache.get.return_value = None  # cache miss
+
+        llm = MagicMock()
+        llm.complete.return_value = "answer"
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
+            synthesize_why(target, tmp_path, llm, gh=mock_gh, pr_cache=mock_cache)
+
+        mock_gh.get_prs_for_commit.assert_called_once_with(sha)
+        mock_cache.set.assert_called_once_with(sha, fetched_prs)
+
+    def test_gh_none_no_fetch(self, tmp_path: Path) -> None:
+        """When gh=None, no PR fetching occurs and resolved_prs stays empty."""
+        commits, _f, target = self._make_setup(tmp_path, n=1)
+        llm = MagicMock()
+        llm.complete.return_value = "answer"
+        captured: list = []
+
+        def fake_build_prompt(t, code, cwprs, **kwargs):
+            captured.extend(cwprs)
+            return [MagicMock()]
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, side_effect=fake_build_prompt),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
+            synthesize_why(target, tmp_path, llm, gh=None)
+
+        assert all(cwpr.pr_number is None for cwpr in captured)
+
+    def test_explicit_prs_take_precedence_over_gh(self, tmp_path: Path) -> None:
+        """When both prs={sha: meta} and gh=mock_client are provided,
+        gh.get_prs_for_commit is NOT called (explicit prs dict wins)."""
+        from why.github import GitHubClient
+        from why.prompts import PRMetadata
+
+        commits, _f, target = self._make_setup(tmp_path, n=1)
+        sha = commits[0].sha
+        explicit_prs = {sha: PRMetadata(11, "Explicit PR", "explicit body")}
+        mock_gh = MagicMock(spec=GitHubClient)
+
+        llm = MagicMock()
+        llm.complete.return_value = "answer"
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
+            synthesize_why(target, tmp_path, llm, prs=explicit_prs, gh=mock_gh)
+
+        mock_gh.get_prs_for_commit.assert_not_called()
+
+    def test_auth_error_continues_without_prs(self, tmp_path: Path) -> None:
+        """When gh.get_prs_for_commit raises GitHubAuthError, synthesize_why
+        completes successfully (no exception propagated) and a warning is printed."""
+        from why.github import GitHubAuthError, GitHubClient
+
+        commits, _f, target = self._make_setup(tmp_path, n=1)
+        mock_gh = MagicMock(spec=GitHubClient)
+        mock_gh.get_prs_for_commit.side_effect = GitHubAuthError("401 Unauthorized")
+
+        llm = MagicMock()
+        llm.complete.return_value = "answer"
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT),
+            patch(_PATCH_DIFF, return_value=""),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+            patch(_PATCH_CLICK) as mock_click,
+        ):
+            result = synthesize_why(target, tmp_path, llm, gh=mock_gh)
+
+        # Must complete without raising
+        assert result.startswith("answer")
+        # Must emit a warning to stderr
+        echo_calls = mock_click.echo.call_args_list
+        assert any(
+            call.kwargs.get("err") is True
+            for call in echo_calls
+        ), f"Expected a warning echo with err=True, got: {echo_calls}"
 
 
 class TestSynthesizeWhyBriefFlag:


### PR DESCRIPTION
## Related Issues
Closes #24, #25, #26, #27 (M2 — GitHub PR integration)

## What
Full GitHub PR integration for `why`: when analyzing a GitHub-hosted repo, the tool now fetches PR metadata for the key commits it selects and injects PR title + body into the synthesis prompt.

- **`src/why/github.py`** — `GitHubClient` using `urllib.request` (no new dependencies). Token discovery: `GITHUB_TOKEN` env var → `gh auth token` → unauthenticated (60 req/hr). Raises `GitHubAuthError` on 401/403; returns `[]` on all other failures.
- **`src/why/cache.py`** — `PRCache`: XDG-aware SHA-keyed JSON cache at `~/.cache/why/<owner__repo>.json`. 30-day TTL, atomic writes via temp-file rename.
- **`src/why/prompts.py`** — `PRMetadata` gains `title: str`; `CommitWithPR` gains `pr_title`; `_render_commit` renders `**PR #N:** \`title\`` + body truncated to 1000 chars; PR section omitted entirely when no PR (no more "N/A").
- **`src/why/synth.py`** — `synthesize_why` gets `gh: GitHubClient | None` + `pr_cache: PRCache | None`. Cache-first fetch loop runs after key-commit selection (≤5 API calls per invocation). Explicit `prs` dict still takes precedence for backward compatibility.
- **`src/why/cli.py`** — `--no-cache` flag; GitHub client initialized when `github.com` remote detected; path-traversal guard on cache slug construction.

## Why
PR bodies carry the richer "why" context that commit messages often lack — trade-off discussion, issue links, reviewer feedback. Injecting them improves synthesis quality for GitHub-hosted repos without breaking anything for non-GitHub or unauthenticated cases.

## How
- Fetch timing: **after** key-commit selection (not before) — keeps API calls bounded at ≤5 regardless of history length. The scoring `+3.0` PR bonus is intentionally deferred to M3 (requires pre-fetch of full history).
- Transport: `urllib.request` only — zero new runtime dependencies.
- Degradation: missing token, API error, non-GitHub remote → `prs` dict stays empty, synthesis continues without PR context. Warning printed to stderr on auth failure only.

## Security fixes applied during review
- PR title wrapped in inline code fence (\`title\`) to prevent Markdown injection via `**` sequences
- Cache slug validated to reject `..` / `/` components (path traversal guard)
- `gh auth token` output validated to reject embedded whitespace (HTTP header injection guard)
- `_is_expired` catches `TypeError` for naive datetimes from older cache files

## Test Steps
```bash
uv run python -m pytest -x -q   # 307 passed

# Manual smoke test (GitHub repo required):
export GITHUB_TOKEN=<your-token>
why src/why/synth.py synthesize_why
# → should include PR context in output for commits that have associated PRs
```

## Other Notes
- `_get_repo_url` is currently imported as a private function from `synth.py` into `cli.py` — should move to `git.py` in a follow-up (noted, not blocking)
- `synthesize_why` now has 11 params — a `SynthesisConfig` dataclass is the right next step when the next flag lands