### PR TITLE
docs: document GitHub token auth strategy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ Set `GROQ_API_KEY` before running (see [Install](#install) above).
 
 By default `why` uses Groq as the LLM provider. The active provider is controlled by `WHY_LLM_PROVIDER` (default: `groq`). Currently only `groq` is supported — other providers are planned.
 
+### GitHub token (optional but recommended)
+
+`why` fetches PR metadata from the GitHub API. It discovers a token automatically:
+
+1. `GITHUB_TOKEN` env var — set this if you prefer explicit control
+2. `gh` CLI — if you have [GitHub CLI](https://cli.github.com) installed and have run `gh auth login`, `why` picks up the token automatically
+3. Unauthenticated — works for public repos but is rate-limited to 60 requests/hour
+
+For private repos or heavy use, set a token explicitly:
+
+```sh
+export GITHUB_TOKEN=your_personal_access_token
+```
+
+A classic PAT with `repo` (read) scope is sufficient.
+
 ### Analyse a file
 
 ```bash


### PR DESCRIPTION
## Related Links
- Closes #90

## What
Adds a `### GitHub token (optional but recommended)` subsection under `### Prerequisites` in the README.

## Why
Users installing via Homebrew or pip have no visibility into how `why` discovers a GitHub token. Someone without `gh` CLI who hits the 60 req/hr unauthenticated rate limit sees a confusing error with no guidance.

## How
Documents the three-tier token discovery order (`GITHUB_TOKEN` env var → `gh` CLI → unauthenticated) and provides a one-liner for setting a PAT with the minimum required `repo` read scope.

## Test Steps
- [ ] Read the new README section and verify it accurately reflects the logic in `src/why/github.py`
- [ ] Confirm the fenced code block renders correctly on GitHub

## Other Notes
Docs-only change — no code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)