### PR TITLE
feat: openai-compatible LLM provider for local models

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,16 @@ export GROQ_API_KEY=your_key_here
 
 Set `GROQ_API_KEY` before running (see [Install](#install) above).
 
-By default `why` uses Groq as the LLM provider. The active provider is controlled by `WHY_LLM_PROVIDER` (default: `groq`). Currently only `groq` is supported — other providers are planned.
+By default `why` uses Groq as the LLM provider. The active provider is controlled by `WHY_LLM_PROVIDER` (default: `groq`). Two providers are currently supported:
+
+- **`groq`** (default) — Groq cloud API; requires `GROQ_API_KEY`.
+- **`openai-compatible`** — any OpenAI-compatible local server (Ollama, llama.cpp, LM Studio, vLLM, TGI, …); requires `WHY_LLM_BASE_URL`. Example with Ollama:
+
+  ```sh
+  WHY_LLM_PROVIDER=openai-compatible \
+  WHY_LLM_BASE_URL=http://localhost:11434/v1 \
+  why --model qwen2.5:3b ...
+  ```
 
 ### GitHub token (optional but recommended)
 

--- a/docs/sleipnir/design-issue-93-openai-compatible.md
+++ b/docs/sleipnir/design-issue-93-openai-compatible.md
@@ -1,0 +1,87 @@
+# Design — Issue #93: OpenAI-compatible LLM provider
+
+**Issue:** [#93](https://github.com/tarungulati1988/why/issues/93)
+**Branch:** `sleipnir/issue-93-openai-compatible`
+**Depends on:** #92 (merged) — Backend Protocol + retry loop refactor
+**Scope:** small (~1-3h)
+
+## Problem
+
+`why` only works with Groq today. Users want local synthesis (Ollama, llama.cpp `server`, LM Studio, vLLM, HF TGI) for privacy / cost / offline. All five expose the same OpenAI-compatible `/v1/chat/completions` shape, so one connector covers them all.
+
+The provider-agnostic retry loop (#92) made this trivial: add a class implementing `Backend`, wire one new branch in `LLMClient.__init__`.
+
+## Decisions
+
+### 1. Location: `src/why/_backends/openai_compatible.py`
+
+The `_backends/` package was created in #92 specifically to host new providers. `GroqBackend` was kept inline only because existing tests patch `why.llm.groq_sdk.Groq` — no such constraint for `openai`. Use the package as intended.
+
+`llm.py` imports the new backend lazily inside the `elif` branch to keep `openai` an importable-but-not-imported dependency for users who only use Groq.
+
+### 2. Connection errors retry: `openai.APIConnectionError → LLMServerError`
+
+Local servers restart and crash far more than Groq. Mapping connection errors to the retryable bucket gives `ollama serve` a 7-second window (1s + 2s + 4s) to come back. Bounded — won't hang forever, won't fail on a 200ms blip.
+
+`openai.RateLimitError`, `APITimeoutError`, retryable `APIStatusError` (429/500/503) follow the same pattern as `GroqBackend`. Non-retryable status codes raise plain `LLMError`.
+
+### 3. `ChatResult` populates all three token fields
+
+`GroqBackend` sets `prompt_tokens`, `completion_tokens`, **and** `total_tokens`. Mirror that. The verbose-logging path in `LLMClient.complete()` prefers `result.total_tokens` over the computed sum; skipping it forces the fallback unnecessarily.
+
+### 4. Defaults
+
+- `WHY_LLM_API_KEY` defaults to literal `"not-needed"` — Ollama ignores it, but the OpenAI SDK rejects empty.
+- `WHY_LLM_BASE_URL` is **required** when `WHY_LLM_PROVIDER=openai-compatible`. Missing → `LLMMissingKeyError("WHY_LLM_BASE_URL not set")` at construction.
+- No normalization of `base_url` (don't auto-append `/v1`). Trust user input; Ollama users will pass `http://localhost:11434/v1`, llama.cpp users may pass a different path.
+
+### 5. Dependency
+
+Add `openai>=1.40` to `[project.dependencies]` in `pyproject.toml`. Required (not optional/extras) — keeps install instructions simple and the package is small (~1MB wheel).
+
+## File layout
+
+```
+src/why/_backends/
+  base.py                    (unchanged from #92)
+  openai_compatible.py       NEW — OpenAICompatibleBackend
+  __init__.py                add re-export
+src/why/llm.py               replace NotImplementedError("openai")
+                             branch with openai-compatible wiring
+tests/test_openai_compatible_backend.py  NEW
+tests/test_llm.py            extend: provider resolution + missing base_url
+pyproject.toml               add openai>=1.40
+```
+
+## Acceptance
+
+- `LLMClient(provider="openai-compatible")` with `WHY_LLM_BASE_URL` set → constructs.
+- Same without `WHY_LLM_BASE_URL` → `LLMMissingKeyError`.
+- Mocked `openai.OpenAI`: `complete()` returns content; `RateLimitError` / `APIConnectionError` retried per loop; non-retryable status raised immediately.
+- Default provider unchanged (Groq).
+- `--model` default unchanged (`llama-3.3-70b-versatile`).
+
+## Strides
+
+```
+Stride 1: OpenAICompatibleBackend exists and translates errors
+  test: tests/test_openai_compatible_backend.py
+  impl: src/why/_backends/openai_compatible.py, src/why/_backends/__init__.py
+  depends: []
+
+Stride 2: LLMClient wires openai-compatible provider
+  test: tests/test_llm.py (extend)
+  impl: src/why/llm.py
+  depends: [1]
+
+Stride 3: Add openai dependency
+  test: (skip — config only; covered by Stride 1's import path)
+  impl: pyproject.toml
+  depends: []
+```
+
+Wave 1: Strides 1 + 3 (independent files). Wave 2: Stride 2.
+
+## Out of scope
+
+Documentation, `num_ctx`/context-window plumbing, citation guardrails, smoke-test against a live Ollama. Per issue, those are tracked separately (#94-#97).

--- a/docs/sleipnir/state.json
+++ b/docs/sleipnir/state.json
@@ -1,12 +1,21 @@
 {
-  "branch": "sleipnir/issue-92-backend-protocol",
+  "branch": "sleipnir/issue-93-openai-compatible",
   "base_ref": "origin/main",
-  "base_sha": "ddec3f76ab58a258828610924dace4bab0f37964",
-  "merge_base": "ddec3f76ab58a258828610924dace4bab0f37964",
-  "dirty_files": [".python-version", "docs/sleipnir/design-issue-92-backend-protocol.md"],
-  "included_files": ["docs/sleipnir/design-issue-92-backend-protocol.md"],
+  "base_sha": "951427b",
+  "merge_base": "951427b",
+  "dirty_files": [".python-version"],
+  "included_files": [
+    "docs/sleipnir/design-issue-93-openai-compatible.md",
+    "src/why/_backends/openai_compatible.py",
+    "src/why/_backends/__init__.py",
+    "src/why/llm.py",
+    "tests/test_openai_compatible_backend.py",
+    "tests/test_llm.py",
+    "pyproject.toml",
+    "uv.lock"
+  ],
   "excluded_files": [".python-version"],
-  "issue": 92,
-  "design_doc": "docs/sleipnir/design-issue-92-backend-protocol.md",
-  "phase": "execution"
+  "issue": 93,
+  "design_doc": "docs/sleipnir/design-issue-93-openai-compatible.md",
+  "phase": "review"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.11"
 dependencies = [
   "click>=8.1",
   "groq>=0.9",
+  "openai>=1.40,<2",
   "rich>=13",
   "tree-sitter>=0.23",
   "tree-sitter-python",

--- a/src/why/_backends/__init__.py
+++ b/src/why/_backends/__init__.py
@@ -1,4 +1,5 @@
 """Internal backends package — protocol and concrete LLM provider adapters."""
 from why._backends.base import Backend, ChatResult
+from why._backends.openai_compatible import OpenAICompatibleBackend
 
-__all__ = ["Backend", "ChatResult"]
+__all__ = ["Backend", "ChatResult", "OpenAICompatibleBackend"]

--- a/src/why/_backends/openai_compatible.py
+++ b/src/why/_backends/openai_compatible.py
@@ -1,0 +1,49 @@
+"""OpenAI-compatible backend — works with Ollama, llama.cpp, LM Studio, vLLM, TGI."""
+from __future__ import annotations
+
+from typing import Any
+
+import openai
+
+from why._backends.base import ChatResult
+from why._errors import (
+    _RETRYABLE_STATUS,
+    LLMError,
+    LLMRateLimitError,
+    LLMServerError,
+    LLMTimeoutError,
+)
+
+
+class OpenAICompatibleBackend:
+    """Backend for any OpenAI-compatible /v1/chat/completions server."""
+
+    def __init__(self, base_url: str, api_key: str) -> None:
+        self._client = openai.OpenAI(base_url=base_url, api_key=api_key)
+
+    def chat(self, model: str, payload: list[Any], **_extra: Any) -> ChatResult:
+        try:
+            r = self._client.chat.completions.create(model=model, messages=payload)
+        except openai.RateLimitError as e:
+            raise LLMRateLimitError(str(e)) from e
+        except openai.APITimeoutError as e:
+            raise LLMTimeoutError(str(e)) from e
+        except openai.APIConnectionError as e:
+            # Local servers (Ollama, llama.cpp) can restart/crash — make this
+            # retryable so the client gets a window to reconnect.
+            raise LLMServerError(f"connection error: {e}") from e
+        except openai.APIStatusError as e:
+            if e.status_code in _RETRYABLE_STATUS:
+                raise LLMServerError(f"status {e.status_code}") from e
+            raise LLMError(f"API error {e.status_code}") from e
+
+        content = r.choices[0].message.content
+        if not content:
+            raise LLMError("model returned no text content")
+        u = r.usage
+        return ChatResult(
+            content=content,
+            prompt_tokens=u.prompt_tokens if u else None,
+            completion_tokens=u.completion_tokens if u else None,
+            total_tokens=u.total_tokens if u else None,
+        )

--- a/src/why/_errors.py
+++ b/src/why/_errors.py
@@ -1,0 +1,30 @@
+"""Shared exception hierarchy for the why LLM client.
+
+Centralised here so that _backends/* can import error types without creating
+a circular dependency through why.llm.
+"""
+
+from __future__ import annotations
+
+# HTTP status codes that warrant a retry (server-side transient errors).
+_RETRYABLE_STATUS = frozenset({429, 500, 503})
+
+
+class LLMError(Exception):
+    """Base exception for all LLM client errors."""
+
+
+class LLMMissingKeyError(LLMError):
+    """Required API key environment variable is absent at construction time."""
+
+
+class LLMRateLimitError(LLMError):
+    """Rate limit retries exhausted (HTTP 429)."""
+
+
+class LLMServerError(LLMError):
+    """Server error retries exhausted (HTTP 500/503)."""
+
+
+class LLMTimeoutError(LLMError):
+    """Timeout retries exhausted."""

--- a/src/why/llm.py
+++ b/src/why/llm.py
@@ -15,15 +15,20 @@ from typing import Any, Literal
 import groq as groq_sdk  # KEEP — tests patch why.llm.groq_sdk.Groq
 
 from why._backends.base import Backend, ChatResult
+from why._errors import (
+    _RETRYABLE_STATUS,
+    LLMError,
+    LLMMissingKeyError,
+    LLMRateLimitError,
+    LLMServerError,
+    LLMTimeoutError,
+)
 
 logger = logging.getLogger("why.llm")
 
 # ---------------------------------------------------------------------------
 # Retry constants
 # ---------------------------------------------------------------------------
-
-# HTTP status codes that warrant a retry (server-side transient errors).
-_RETRYABLE_STATUS = frozenset({429, 500, 503})
 
 # Maximum number of retry attempts after the initial attempt.
 _MAX_RETRIES = 3
@@ -36,6 +41,15 @@ _BASE_DELAY = 1.0
 # Public types
 # ---------------------------------------------------------------------------
 
+# Re-export so `from why.llm import LLMError` etc. continue to work.
+__all__ = [
+    "LLMError",
+    "LLMMissingKeyError",
+    "LLMRateLimitError",
+    "LLMServerError",
+    "LLMTimeoutError",
+]
+
 
 @dataclass
 class Message:
@@ -47,26 +61,6 @@ class Message:
     def __post_init__(self) -> None:
         if self.role not in ("user", "assistant"):
             raise ValueError(f"Message.role must be 'user' or 'assistant', got {self.role!r}")
-
-
-class LLMError(Exception):
-    """Base exception for all LLM client errors."""
-
-
-class LLMMissingKeyError(LLMError):
-    """Required API key environment variable is absent at construction time."""
-
-
-class LLMRateLimitError(LLMError):
-    """Rate limit retries exhausted (HTTP 429)."""
-
-
-class LLMServerError(LLMError):
-    """Server error retries exhausted (HTTP 500/503)."""
-
-
-class LLMTimeoutError(LLMError):
-    """Timeout retries exhausted."""
 
 
 # ---------------------------------------------------------------------------
@@ -93,7 +87,7 @@ class GroqBackend:
             raise LLMError(f"API error {e.status_code}") from e
 
         content = r.choices[0].message.content
-        if content is None:
+        if not content:
             raise LLMError("model returned no text content")
         u = r.usage
         return ChatResult(
@@ -116,6 +110,14 @@ class LLMClient:
       1. ``provider`` constructor argument
       2. ``WHY_LLM_PROVIDER`` environment variable
       3. Default: ``"groq"``
+
+    Supported providers:
+
+    - ``"groq"`` — Groq cloud API. Requires ``GROQ_API_KEY``.
+    - ``"openai-compatible"`` — Any OpenAI-compatible server (Ollama, llama.cpp,
+      LM Studio, vLLM, TGI, …). Requires ``WHY_LLM_BASE_URL`` (e.g.
+      ``http://localhost:11434/v1``). ``WHY_LLM_API_KEY`` is optional; defaults
+      to ``"not-needed"`` for servers that do not require authentication.
     """
 
     def __init__(
@@ -135,10 +137,32 @@ class LLMClient:
             if not api_key:
                 raise LLMMissingKeyError("GROQ_API_KEY not set")
             self._backend: Backend = GroqBackend(api_key)
+        elif resolved_provider == "openai-compatible":
+            base_url = os.getenv("WHY_LLM_BASE_URL")
+            if not base_url:
+                raise LLMMissingKeyError("WHY_LLM_BASE_URL not set")
+            api_key = os.getenv("WHY_LLM_API_KEY") or "not-needed"
+            # Warn when sending to a non-local host without an explicit API key,
+            # since prompt data will be transmitted without credentials.
+            _local_prefixes = ("http://localhost", "http://127.", "http://[::1]")
+            if not os.getenv("WHY_LLM_API_KEY") and not base_url.startswith(_local_prefixes):
+                logger.warning(
+                    "WHY_LLM_BASE_URL points to a non-local host (%s) but WHY_LLM_API_KEY is "
+                    "not set; prompt data will be sent without credentials.",
+                    base_url,
+                )
+            # Lazy import — keeps `openai` an importable-but-not-imported dependency
+            # for users who only use Groq.
+            from why._backends.openai_compatible import OpenAICompatibleBackend
+            self._backend = OpenAICompatibleBackend(base_url=base_url, api_key=api_key)
         elif resolved_provider == "anthropic":
             raise NotImplementedError("anthropic backend not yet implemented")
         elif resolved_provider == "openai":
-            raise NotImplementedError("openai backend not yet implemented")
+            raise NotImplementedError(
+                "Direct OpenAI API support is not yet implemented. "
+                "For OpenAI-compatible local servers (Ollama, llama.cpp, LM Studio, vLLM, TGI), "
+                "use provider='openai-compatible' and set WHY_LLM_BASE_URL."
+            )
         else:
             raise LLMError(f"unknown provider: {resolved_provider!r}")
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -98,6 +98,25 @@ def test_complete_returns_content_string(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 # ---------------------------------------------------------------------------
+# Test 2b: None or empty content from Groq raises LLMError
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("empty_content", [None, ""])
+def test_groq_empty_content_raises_llm_error(
+    monkeypatch: pytest.MonkeyPatch,
+    empty_content: str | None,
+) -> None:
+    """When GroqBackend receives None or '' content, complete() must raise LLMError."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    mock_client = _make_mock_groq_client(content=empty_content)
+
+    with patch("why.llm.groq_sdk.Groq", return_value=mock_client):
+        llm = LLMClient()
+        with pytest.raises(LLMError, match="model returned no text content"):
+            llm.complete("sys", [Message("user", "hi")])
+
+
+# ---------------------------------------------------------------------------
 # Test 3: missing GROQ_API_KEY raises LLMMissingKeyError at construction
 # ---------------------------------------------------------------------------
 
@@ -361,3 +380,151 @@ def test_non_retryable_llm_error_propagates_without_retry(
     assert "API error 400" in str(exc_info.value)
     assert call_count["n"] == 1
     mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 15: openai-compatible provider constructs an OpenAICompatibleBackend
+# ---------------------------------------------------------------------------
+
+def test_provider_openai_compatible_constructs_with_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LLMClient with openai-compatible provider must build an OpenAICompatibleBackend."""
+    from unittest.mock import patch as _patch
+
+    from why._backends.openai_compatible import OpenAICompatibleBackend
+
+    monkeypatch.setenv("WHY_LLM_PROVIDER", "openai-compatible")
+    monkeypatch.setenv("WHY_LLM_BASE_URL", "http://localhost:11434/v1")
+
+    with _patch("openai.OpenAI"):
+        client = LLMClient()
+
+    assert isinstance(client._backend, OpenAICompatibleBackend)
+
+
+# ---------------------------------------------------------------------------
+# Test 16: openai-compatible without WHY_LLM_BASE_URL raises LLMMissingKeyError
+# ---------------------------------------------------------------------------
+
+def test_provider_openai_compatible_missing_base_url_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LLMClient() with openai-compatible but no WHY_LLM_BASE_URL must raise LLMMissingKeyError."""
+    monkeypatch.setenv("WHY_LLM_PROVIDER", "openai-compatible")
+    monkeypatch.delenv("WHY_LLM_BASE_URL", raising=False)
+
+    with pytest.raises(LLMMissingKeyError, match="WHY_LLM_BASE_URL"):
+        LLMClient()
+
+
+# ---------------------------------------------------------------------------
+# Test 17: openai-compatible with no WHY_LLM_API_KEY defaults to "not-needed"
+# ---------------------------------------------------------------------------
+
+def test_provider_openai_compatible_default_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When WHY_LLM_API_KEY is absent, api_key='not-needed' is passed to openai.OpenAI."""
+    from unittest.mock import patch as _patch
+
+    monkeypatch.setenv("WHY_LLM_PROVIDER", "openai-compatible")
+    monkeypatch.setenv("WHY_LLM_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.delenv("WHY_LLM_API_KEY", raising=False)
+
+    with _patch("openai.OpenAI") as mock_openai_cls:
+        LLMClient()
+
+    _, kwargs = mock_openai_cls.call_args
+    assert kwargs.get("api_key") == "not-needed"
+
+
+# ---------------------------------------------------------------------------
+# Test 18: openai-compatible uses WHY_LLM_API_KEY when set
+# ---------------------------------------------------------------------------
+
+def test_provider_openai_compatible_custom_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When WHY_LLM_API_KEY=sk-test-123, that exact value is passed to openai.OpenAI."""
+    from unittest.mock import patch as _patch
+
+    monkeypatch.setenv("WHY_LLM_PROVIDER", "openai-compatible")
+    monkeypatch.setenv("WHY_LLM_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.setenv("WHY_LLM_API_KEY", "sk-test-123")
+
+    with _patch("openai.OpenAI") as mock_openai_cls:
+        LLMClient()
+
+    _, kwargs = mock_openai_cls.call_args
+    assert kwargs.get("api_key") == "sk-test-123"
+
+
+# ---------------------------------------------------------------------------
+# Test 19: constructor provider= param overrides WHY_LLM_PROVIDER env var
+# ---------------------------------------------------------------------------
+
+def test_provider_openai_compatible_constructor_param_overrides_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """provider='openai-compatible' kwarg must win over WHY_LLM_PROVIDER=groq env var."""
+    from unittest.mock import patch as _patch
+
+    from why._backends.openai_compatible import OpenAICompatibleBackend
+
+    monkeypatch.setenv("WHY_LLM_PROVIDER", "groq")  # env says groq ...
+    monkeypatch.setenv("WHY_LLM_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.delenv("WHY_LLM_API_KEY", raising=False)
+
+    with _patch("openai.OpenAI"):
+        # ... but constructor kwarg says openai-compatible → must win
+        client = LLMClient(provider="openai-compatible")
+
+    assert isinstance(client._backend, OpenAICompatibleBackend)
+
+
+# ---------------------------------------------------------------------------
+# Test 20: non-local base_url without API key emits a warning
+# ---------------------------------------------------------------------------
+
+def test_non_local_base_url_without_api_key_warns(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """LLMClient should warn when WHY_LLM_BASE_URL is non-local and WHY_LLM_API_KEY is absent."""
+    from unittest.mock import patch as _patch
+
+    monkeypatch.setenv("WHY_LLM_PROVIDER", "openai-compatible")
+    monkeypatch.setenv("WHY_LLM_BASE_URL", "https://remote.example.com/v1")
+    monkeypatch.delenv("WHY_LLM_API_KEY", raising=False)
+
+    with _patch("openai.OpenAI"), caplog.at_level(logging.WARNING, logger="why.llm"):
+        LLMClient()
+
+    assert any(
+        "non-local host" in record.message and "WHY_LLM_API_KEY" in record.message
+        for record in caplog.records
+    ), "Expected a warning about non-local host without credentials"
+
+
+# ---------------------------------------------------------------------------
+# Test 21: local base_url without API key does NOT warn
+# ---------------------------------------------------------------------------
+
+def test_local_base_url_without_api_key_does_not_warn(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """LLMClient must NOT warn when WHY_LLM_BASE_URL is localhost, even without API key."""
+    from unittest.mock import patch as _patch
+
+    monkeypatch.setenv("WHY_LLM_PROVIDER", "openai-compatible")
+    monkeypatch.setenv("WHY_LLM_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.delenv("WHY_LLM_API_KEY", raising=False)
+
+    with _patch("openai.OpenAI"), caplog.at_level(logging.WARNING, logger="why.llm"):
+        LLMClient()
+
+    assert not any(
+        "non-local host" in record.message for record in caplog.records
+    ), "Unexpected warning logged for a localhost base_url"

--- a/tests/test_openai_compatible_backend.py
+++ b/tests/test_openai_compatible_backend.py
@@ -1,0 +1,222 @@
+"""Tests for OpenAICompatibleBackend — written FIRST (TDD).
+
+All external openai API calls are patched via unittest.mock; no network access.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import openai
+import pytest
+
+from why._backends.base import ChatResult
+from why._backends.openai_compatible import OpenAICompatibleBackend
+from why.llm import LLMError, LLMRateLimitError, LLMServerError, LLMTimeoutError
+
+# ---------------------------------------------------------------------------
+# Helpers — build mock openai SDK exception instances
+# ---------------------------------------------------------------------------
+
+def _make_mock_openai_client(content: str = "hello") -> MagicMock:
+    """Return a mock OpenAI client whose create() returns a response with the given content."""
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = content
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 5
+    mock_response.usage.total_tokens = 15
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = MagicMock(return_value=mock_response)
+    return mock_client
+
+
+def _make_api_status_error(status_code: int, message: str = "error") -> openai.APIStatusError:
+    """Build an openai.APIStatusError with the given status code.
+
+    Uses plain APIStatusError (not RateLimitError subclass) so the APIStatusError
+    handler in chat() is exercised, not the dedicated RateLimitError handler.
+    For 500, InternalServerError subclass is also a plain APIStatusError without
+    overriding status_code, so we set it on the mock response directly.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_request = MagicMock()
+    mock_response.request = mock_request
+    # Always use the base APIStatusError so status_code routing in chat() is tested.
+    # Subclasses like RateLimitError are tested separately in test 4.
+    return openai.APIStatusError(message, response=mock_response, body=None)
+
+
+def _make_rate_limit_error() -> openai.RateLimitError:
+    """Build an openai.RateLimitError."""
+    mock_response = MagicMock()
+    mock_response.status_code = 429
+    mock_response.request = MagicMock()
+    return openai.RateLimitError("rate limited", response=mock_response, body=None)
+
+
+def _make_timeout_error() -> openai.APITimeoutError:
+    """Build an openai.APITimeoutError."""
+    mock_request = MagicMock()
+    return openai.APITimeoutError(request=mock_request)
+
+
+def _make_connection_error() -> openai.APIConnectionError:
+    """Build an openai.APIConnectionError."""
+    mock_request = MagicMock()
+    return openai.APIConnectionError(request=mock_request)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Successful chat — ChatResult populated
+# ---------------------------------------------------------------------------
+
+def test_successful_chat_returns_populated_chat_result() -> None:
+    """chat() must return a ChatResult with content and token counts populated."""
+    mock_client = _make_mock_openai_client(content="test response")
+
+    with patch("openai.OpenAI", return_value=mock_client):
+        backend = OpenAICompatibleBackend(base_url="http://localhost:11434/v1", api_key="ollama")
+        result = backend.chat("llama3", [{"role": "user", "content": "hello"}])
+
+    assert isinstance(result, ChatResult)
+    assert result.content == "test response"
+    assert result.prompt_tokens == 10
+    assert result.completion_tokens == 5
+    assert result.total_tokens == 15
+
+
+# ---------------------------------------------------------------------------
+# Test 2: None or empty content raises LLMError
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("empty_content", [None, ""])
+def test_empty_content_raises_llm_error(empty_content: str | None) -> None:
+    """When choices[0].message.content is None or '', chat() must raise LLMError."""
+    mock_client = _make_mock_openai_client(content=empty_content)
+
+    with patch("openai.OpenAI", return_value=mock_client):
+        backend = OpenAICompatibleBackend(base_url="http://localhost:11434/v1", api_key="ollama")
+        with pytest.raises(LLMError, match="model returned no text content"):
+            backend.chat("llama3", [{"role": "user", "content": "hello"}])
+
+
+# ---------------------------------------------------------------------------
+# Test 3: No usage object — tokens are all None, content returned
+# ---------------------------------------------------------------------------
+
+def test_no_usage_object_tokens_are_none() -> None:
+    """When r.usage is None, all token fields must be None but content returned."""
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = "response text"
+    mock_response.usage = None
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = MagicMock(return_value=mock_response)
+
+    with patch("openai.OpenAI", return_value=mock_client):
+        backend = OpenAICompatibleBackend(base_url="http://localhost:11434/v1", api_key="ollama")
+        result = backend.chat("llama3", [{"role": "user", "content": "hello"}])
+
+    assert result.content == "response text"
+    assert result.prompt_tokens is None
+    assert result.completion_tokens is None
+    assert result.total_tokens is None
+
+
+# ---------------------------------------------------------------------------
+# Test 4: RateLimitError → LLMRateLimitError
+# ---------------------------------------------------------------------------
+
+def test_rate_limit_error_raises_llm_rate_limit_error() -> None:
+    """openai.RateLimitError must be translated to LLMRateLimitError."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = _make_rate_limit_error()
+
+    with patch("openai.OpenAI", return_value=mock_client):
+        backend = OpenAICompatibleBackend(base_url="http://localhost:11434/v1", api_key="ollama")
+        with pytest.raises(LLMRateLimitError):
+            backend.chat("llama3", [{"role": "user", "content": "hello"}])
+
+
+# ---------------------------------------------------------------------------
+# Test 5: APITimeoutError → LLMTimeoutError
+# ---------------------------------------------------------------------------
+
+def test_api_timeout_error_raises_llm_timeout_error() -> None:
+    """openai.APITimeoutError must be translated to LLMTimeoutError."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = _make_timeout_error()
+
+    with patch("openai.OpenAI", return_value=mock_client):
+        backend = OpenAICompatibleBackend(base_url="http://localhost:11434/v1", api_key="ollama")
+        with pytest.raises(LLMTimeoutError):
+            backend.chat("llama3", [{"role": "user", "content": "hello"}])
+
+
+# ---------------------------------------------------------------------------
+# Test 6: APIConnectionError → LLMServerError (retryable for local LLMs)
+# ---------------------------------------------------------------------------
+
+def test_api_connection_error_raises_llm_server_error() -> None:
+    """openai.APIConnectionError must be translated to LLMServerError (retryable)."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = _make_connection_error()
+
+    with patch("openai.OpenAI", return_value=mock_client):
+        backend = OpenAICompatibleBackend(base_url="http://localhost:11434/v1", api_key="ollama")
+        with pytest.raises(LLMServerError, match="connection error"):
+            backend.chat("llama3", [{"role": "user", "content": "hello"}])
+
+
+# ---------------------------------------------------------------------------
+# Test 7: APIStatusError 429 → LLMServerError (retryable)
+# ---------------------------------------------------------------------------
+
+def test_api_status_error_429_raises_llm_server_error() -> None:
+    """openai.APIStatusError with status 429 must be translated to LLMServerError."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = _make_api_status_error(429)
+
+    with patch("openai.OpenAI", return_value=mock_client):
+        backend = OpenAICompatibleBackend(base_url="http://localhost:11434/v1", api_key="ollama")
+        with pytest.raises(LLMServerError, match="status 429"):
+            backend.chat("llama3", [{"role": "user", "content": "hello"}])
+
+
+# ---------------------------------------------------------------------------
+# Test 8: APIStatusError 500 → LLMServerError (retryable)
+# ---------------------------------------------------------------------------
+
+def test_api_status_error_500_raises_llm_server_error() -> None:
+    """openai.APIStatusError with status 500 must be translated to LLMServerError."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = _make_api_status_error(500)
+
+    with patch("openai.OpenAI", return_value=mock_client):
+        backend = OpenAICompatibleBackend(base_url="http://localhost:11434/v1", api_key="ollama")
+        with pytest.raises(LLMServerError, match="status 500"):
+            backend.chat("llama3", [{"role": "user", "content": "hello"}])
+
+
+# ---------------------------------------------------------------------------
+# Test 9: APIStatusError 400 → LLMError (non-retryable)
+# ---------------------------------------------------------------------------
+
+def test_api_status_error_400_raises_llm_error_non_retryable() -> None:
+    """openai.APIStatusError with status 400 must be translated to plain LLMError
+    (non-retryable)."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = _make_api_status_error(400)
+
+    with patch("openai.OpenAI", return_value=mock_client):
+        backend = OpenAICompatibleBackend(base_url="http://localhost:11434/v1", api_key="ollama")
+        with pytest.raises(LLMError) as exc_info:
+            backend.chat("llama3", [{"role": "user", "content": "hello"}])
+
+    # Must be plain LLMError, not LLMServerError (which is retryable)
+    assert type(exc_info.value) is LLMError, (
+        f"expected exact LLMError, got {type(exc_info.value).__name__}"
+    )
+    assert "API error 400" in str(exc_info.value)

--- a/uv.lock
+++ b/uv.lock
@@ -73,6 +73,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "groq" },
+    { name = "openai" },
     { name = "rich" },
     { name = "tree-sitter" },
     { name = "tree-sitter-go" },
@@ -91,6 +92,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "groq", specifier = ">=0.9" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
+    { name = "openai", specifier = ">=1.40,<2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "rich", specifier = ">=13" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
@@ -170,6 +172,96 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/1f/198ae537fccb7080a0ed655eb56abf64a92f79489dfbf79f40fa34225bcd/jiter-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7e791e247b8044512e070bd1f3633dc08350d32776d2d6e7473309d0edf256a2", size = 316896, upload-time = "2026-04-10T14:26:01.986Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/34/da67cff3fce964a36d03c3e365fb0f8726ade2a6cfd4d3c70107e216ead6/jiter-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71527ce13fd5a0c4e40ad37331f8c547177dbb2dd0a93e5278b6a5eecf748804", size = 321085, upload-time = "2026-04-10T14:26:03.364Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/36/4c72e67180d4e71a4f5dcf7886d0840e83c49ab11788172177a77570326e/jiter-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02c4a7ab56f746014874f2c525584c0daca1dec37f66fd707ecef3b7e5c2228c", size = 347393, upload-time = "2026-04-10T14:26:05.314Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/db/9b39e09ceafa9878235c0fc29e3e3f9b12a4c6a98ea3085b998cadf3accc/jiter-0.14.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:376e9dafff914253bb9d46cdc5f7965607fbe7feb0a491c34e35f92b2770702e", size = 372937, upload-time = "2026-04-10T14:26:06.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/96/0dcba1d7a82c1b720774b48ef239376addbaf30df24c34742ac4a57b67b2/jiter-0.14.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:23ad2a7a9da1935575c820428dd8d2490ce4d23189691ce33da1fc0a58e14e1c", size = 463646, upload-time = "2026-04-10T14:26:08.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e3/f61b71543e746e6b8b805e7755814fc242715c16f1dba58e1cbccb8032c2/jiter-0.14.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54b3ddf5786bc7732d293bba3411ac637ecfa200a39983166d1df86a59a43c9f", size = 380225, upload-time = "2026-04-10T14:26:10.161Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5e/0ddeb7096aca099114abe36c4921016e8d251e6f35f5890240b31f1f60ae/jiter-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c001d5a646c2a50dc055dd526dad5d5245969e8234d2b1131d0451e81f3a373", size = 358682, upload-time = "2026-04-10T14:26:11.574Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d1/fe0c46cd7fda9cad8f1ff9ad217dc61f1e4280b21052ec6dfe88c1446ef2/jiter-0.14.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:834bb5bdabca2e91592a03d373838a8d0a1b8bbde7077ae6913fd2fc51812d00", size = 359973, upload-time = "2026-04-10T14:26:13.316Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/21/f5317f91729b501019184771c80d60abd89907009e7bfa6c7e348c5bdd44/jiter-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4e9178be60e229b1b2b0710f61b9e24d1f4f8556985a83ff4c4f95920eea7314", size = 397568, upload-time = "2026-04-10T14:26:15.212Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/79d8f33fb2bf168db0df5c9cd16fe440a8ada57e929d3677b22712c2568f/jiter-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a7e4ccff04ec03614e62c613e976a3a5860dc9714ce8266f44328bdc8b1cab2c", size = 522535, upload-time = "2026-04-10T14:26:16.956Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/d1e3ff3d2a465e67f08507d74bafb2dcd29eba91dc939820e39e8dea38b8/jiter-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:69539d936fb5d55caf6ecd33e2e884de083ff0ea28579780d56c4403094bb8d9", size = 556709, upload-time = "2026-04-10T14:26:18.5Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/bbb2189f62ace8d95e869aa4c84c9946616f301e2d02895a6f20dcc3bba3/jiter-0.14.0-cp311-cp311-win32.whl", hash = "sha256:4927d09b3e572787cc5e0a5318601448e1ab9391bcef95677f5840c2d00eaa6d", size = 208660, upload-time = "2026-04-10T14:26:20.511Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/86/c500b53dcbf08575f5963e536ebd757a1f7c568272ba5d180b212c9a87fb/jiter-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:42d6ed359ac49eb922fdd565f209c57340aa06d589c84c8413e42a0f9ae1b842", size = 204659, upload-time = "2026-04-10T14:26:22.152Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/a676249049d42cb29bef82233e4fe0524d414cbe3606c7a4b311193c2f77/jiter-0.14.0-cp311-cp311-win_arm64.whl", hash = "sha256:6dd689f5f4a5a33747b28686e051095beb214fe28cfda5e9fe58a295a788f593", size = 194772, upload-time = "2026-04-10T14:26:23.458Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a1/ef34ca2cab2962598591636a1804b93645821201cc0095d4a93a9a329c9d/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:a25ffa2dbbdf8721855612f6dca15c108224b12d0c4024d0ac3d7902132b4211", size = 311366, upload-time = "2026-04-10T14:28:27.943Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/520576a532a6b8a6f42747afed289c8448c879a34d7802fe2c832d4fd38f/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ac9cbaa86c10996b92bd12c91659b60f939f8e28fcfa6bc11a0e90a774ce95b", size = 309873, upload-time = "2026-04-10T14:28:29.688Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7c/c16db114ea1f2f532f198aa8dc39585026af45af362c69a0492f31bc4821/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:844e73b6c56b505e9e169234ea3bdea2ea43f769f847f47ac559ba1d2361ebea", size = 344816, upload-time = "2026-04-10T14:28:31.348Z" },
+    { url = "https://files.pythonhosted.org/packages/99/8f/15e7741ff19e9bcd4d753f7ff22f988fd54592f134ca13701c13ea8c20e0/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e52c076f187405fc21523c746c04399c9af8ece566077ed147b2126f2bcba577", size = 351445, upload-time = "2026-04-10T14:28:33.093Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
 ]
 
 [[package]]
@@ -323,6 +415,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "openai"
+version = "1.109.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/a1/a303104dc55fc546a3f6914c842d3da471c64eec92043aef8f652eb6c524/openai-1.109.1.tar.gz", hash = "sha256:d173ed8dbca665892a6db099b4a2dfac624f94d20a93f46eb0b56aae940ed869", size = 564133, upload-time = "2025-09-24T13:00:53.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/2a/7dd3d207ec669cacc1f186fd856a0f61dbc255d24f6fdc1a6715d6051b0f/openai-1.109.1-py3-none-any.whl", hash = "sha256:6bcaf57086cf59159b8e27447e4e7dd019db5d29a438072fbd49c290c7e65315", size = 948627, upload-time = "2025-09-24T13:00:50.754Z" },
 ]
 
 [[package]]
@@ -539,6 +650,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Related Links

- Closes #93
- Builds on #92 (Backend Protocol refactor)
- Part of the local-LLM series #93–#97

## What

- New provider `openai-compatible` in `LLMClient`, gated by `WHY_LLM_BASE_URL`. Works with Ollama, llama.cpp `server`, LM Studio, vLLM, and HuggingFace TGI — all share the same `/v1/chat/completions` shape.
- New backend `OpenAICompatibleBackend` at `src/why/_backends/openai_compatible.py`, implementing the `Backend` protocol from #92.
- Refactor: extracted `LLMError` hierarchy + `_RETRYABLE_STATUS` to `src/why/_errors.py`. `why.llm` re-exports the names so existing imports keep working.
- New env vars:
  - `WHY_LLM_BASE_URL` — required when `WHY_LLM_PROVIDER=openai-compatible`. Missing → `LLMMissingKeyError`.
  - `WHY_LLM_API_KEY` — optional, defaults to `"not-needed"` (Ollama ignores it; OpenAI SDK rejects empty).
- `openai>=1.40,<2` added to dependencies (capped to avoid surprise major-version breakage).
- Default provider unchanged (`groq`). `--model` default unchanged.
- README updated with an Ollama usage example.
- Empty-string content (`""`) now correctly rejected from both backends — local models occasionally emit empty completions.

## Why

Today `why` only works with a Groq API key. Users want local synthesis for privacy / cost / offline. The OpenAI-compatible API is the de-facto standard across the five major local-LLM runtimes, so one connector covers all of them.

The `Backend` protocol from #92 made this addition surgical — one new class, one new branch in `LLMClient.__init__`, no changes to the retry loop.

## How

- Lazy import of `OpenAICompatibleBackend` inside `LLMClient.__init__`'s `elif` branch — Groq-only users don't pay the `openai` import cost.
- Error translation mirrors `GroqBackend`. `APIConnectionError` maps to `LLMServerError` (retryable) so a brief `ollama serve` restart doesn't fail the run; the existing 1s/2s/4s backoff gives a 7-second window.
- `_errors.py` extraction (review-driven) eliminates the circular-import workaround and removes a duplicated `_RETRYABLE_STATUS` constant. Both backends now import from one source of truth.
- Security: when `WHY_LLM_BASE_URL` points to a non-localhost host AND `WHY_LLM_API_KEY` is unset, `LLMClient` logs a warning — the `"not-needed"` sentinel would otherwise let prompt data leave the machine silently to a remote server with no credential check.

## Test Steps

- [x] Unit: 333 tests pass (was 314 before this PR; +19 net).
- [x] Lint: `uv run ruff check src/ tests/` clean.
- [x] Types: `uv run mypy src/why` clean.
- [x] Verify Groq path unchanged (existing tests cover provider resolution + retry).
- [ ] Manual smoke (recommended post-merge):
  ```
  ollama pull qwen2.5:3b && ollama serve
  WHY_LLM_PROVIDER=openai-compatible \
  WHY_LLM_BASE_URL=http://localhost:11434/v1 \
  why src/why/llm.py --model qwen2.5:3b
  ```

## Other Notes

- Out of scope (separate issues in the local-LLM series):
  - Context-window auto-shrink and `num_ctx` plumbing for Ollama (#94).
  - Citation guardrails for weaker models (#95).
  - Direct OpenAI API support (`provider="openai"` still raises `NotImplementedError`, but the message now clearly distinguishes that case from `openai-compatible`).
- `GroqBackend` remains inline in `llm.py` (intentional — preserves the existing test patch path `why.llm.groq_sdk.Groq`). Moving it to `_backends/` is deferred to a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)