### PR TITLE
feat: auto-shrink prompt for context-constrained LLM providers (#94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ By default `why` uses Groq as the LLM provider. The active provider is controlle
   why --model qwen2.5:3b ...
   ```
 
+#### Auto-shrink for small context windows
+
+Local 3B-class models often have small context windows (Ollama's default `num_ctx` is 2048). `why` auto-shrinks the prompt to fit:
+
+- **`WHY_LLM_MAX_CTX`** — token budget for prompt assembly. Set to a positive integer to enable; set to `0` to disable.
+- When unset, defaults to **`4096` for `openai-compatible`** providers and is **disabled for `groq`**.
+- When shrinking fires, `why` drops the oldest commits first and truncates each remaining diff to 80 lines, then prints a single warning to stderr describing what was dropped.
+- `--max-commits` is honored *before* shrinking (user cap wins).
+- **Ollama `num_ctx`:** Ollama's default `num_ctx` is 2048. Bump it (Modelfile `PARAMETER num_ctx 4096` or set per-request) to match `WHY_LLM_MAX_CTX`'s default of 4096 — otherwise the prompt still overflows.
+
 ### GitHub token (optional but recommended)
 
 `why` fetches PR metadata from the GitHub API. It discovers a token automatically:

--- a/docs/sleipnir/design-issue-94-auto-shrink.md
+++ b/docs/sleipnir/design-issue-94-auto-shrink.md
@@ -1,0 +1,112 @@
+# Design — Issue #94: Auto-shrink commits and diffs for context-constrained providers
+
+**Issue:** [#94](https://github.com/tarungulati1988/why/issues/94)
+**Branch:** `sleipnir/issue-94-auto-shrink-context`
+**Depends on:** #93 (merged) — openai-compatible provider
+**Scope:** small (~1-3h)
+
+## Problem
+
+Local 3B-class models behind `openai-compatible` (Ollama default `num_ctx=2048`, qwen2.5:3b) degrade sharply once the prompt fills their window. `why`'s prompt routinely runs 8K–20K tokens. Without shrinking, users see truncated mid-sentence answers or the model regressing into hallucination.
+
+The user-facing fix is auto-shrink with a visible warning, not silent failure.
+
+## Decisions
+
+### 1. Hook location: `src/why/synth.py`, after `commits_with_prs` is built
+
+Insert between commit assembly (synth.py:250) and prompt build (synth.py:252). `system_prompt` is currently built *after* `messages` — reorder so it's available for the budget computation.
+
+### 2. Env var with auto-default for openai-compatible
+
+`WHY_LLM_MAX_CTX` semantics:
+
+| State | Behavior |
+|---|---|
+| Set to positive int | Shrink to that target |
+| Set to `0` | Disable (escape hatch) |
+| Unset, provider=`openai-compatible` | **Default to 4096** |
+| Unset, provider=`groq` | Disable (no shrinking) |
+
+Provider is read from the same source as `LLMClient`: `WHY_LLM_PROVIDER` env, default `groq`. We do **not** thread the `LLMClient` instance into `synthesize_why` for this — the env-var read is local and deterministic.
+
+### 3. Naive char/4 token estimate
+
+`len(text) // 4`. No `tiktoken` dependency. The issue's out-of-scope list explicitly rejects real tokenization and the 15% headroom (`target * 0.85`) absorbs estimate error.
+
+### 4. Diff truncation: 80 lines + sentinel
+
+Per issue spec. `"\n".join(lines[:80]) + f"\n... [truncated {N-80} lines]"`. No hunk-aware logic in v1.
+
+### 5. Drop oldest first
+
+Per issue spec. Trade-off acknowledged: oldest commit is often the most informative ("why does this exist?") commit. Future issue can add relevance ranking if user testing shows it matters.
+
+### 6. Combined warning, not two lines
+
+When auto-default kicked in **and** something was dropped/truncated, single stderr line includes the disable hint:
+
+```
+⚠ Auto-shrunk for local model: dropped N commit(s), truncated M diff(s). Set WHY_LLM_MAX_CTX=0 to disable.
+```
+
+When the user explicitly set `WHY_LLM_MAX_CTX`, the disable hint is omitted (they already know).
+
+### 7. `--max-commits` ordering
+
+User cap (`max_commits`) is applied during history selection (synth.py:191) — already happens before shrinking. No code change needed; just verify in tests.
+
+## File layout
+
+```
+src/why/synth.py        Add _estimate_tokens, _shrink_for_budget, _resolve_max_ctx;
+                        wire into synthesize_why between commit assembly and prompt build
+tests/test_synth.py     Extend with shrink tests
+                        (or new tests/test_shrink.py if test_synth.py is crowded)
+README.md               Document WHY_LLM_MAX_CTX in the provider section
+```
+
+## Acceptance
+
+- `WHY_LLM_MAX_CTX=2048` with prompt that needs shrinking → drops oldest commits, truncates diffs >80 lines, emits warning.
+- `WHY_LLM_MAX_CTX=2048` with prompt that already fits → no warning, no mutation.
+- Provider=`openai-compatible`, `WHY_LLM_MAX_CTX` unset → defaults to 4096.
+- Provider=`openai-compatible`, `WHY_LLM_MAX_CTX=0` → no shrinking (escape hatch).
+- Provider=`groq`, `WHY_LLM_MAX_CTX` unset → no shrinking (current behavior).
+- `--max-commits 3` + shrink budget that fits 5 → 3 commits passed to shrink, no further drops.
+- Diff with 200 lines → truncated to 80 + sentinel.
+
+## Strides
+
+```
+Stride 1: _estimate_tokens + _shrink_for_budget pure helpers
+  test: tests/test_shrink.py (NEW)
+  impl: src/why/synth.py (add helpers)
+  depends: []
+
+Stride 2: _resolve_max_ctx env-var resolver with provider-aware default
+  test: tests/test_shrink.py (extend)
+  impl: src/why/synth.py (add helper)
+  depends: []
+
+Stride 3: Wire into synthesize_why + warning emission
+  test: tests/test_synth.py (extend) or tests/test_shrink.py integration block
+  impl: src/why/synth.py (call site, system_prompt reorder)
+  depends: [1, 2]
+
+Stride 4: README documentation
+  test: (skip — docs only; covered by Stride 3 code paths)
+  impl: README.md
+  depends: [3]
+```
+
+Wave 1: Strides 1 + 2 (independent helpers in same file — dispatch sequentially to avoid edit conflicts). Wave 2: Stride 3. Wave 3: Stride 4.
+
+## Out of scope
+
+- Map-reduce summarization (issue rejects).
+- Real tokenization via `tiktoken` (issue rejects).
+- Relevance-ranked drop order (Approach B; deferred).
+- Hunk-aware diff truncation (deferred).
+- `num_ctx` plumbing into the openai-compatible request (separate issue #95).
+- Citation guardrails for weaker models (separate issue #96).

--- a/docs/sleipnir/state.json
+++ b/docs/sleipnir/state.json
@@ -1,21 +1,18 @@
 {
-  "branch": "sleipnir/issue-93-openai-compatible",
+  "branch": "sleipnir/issue-94-auto-shrink-context",
   "base_ref": "origin/main",
-  "base_sha": "951427b",
-  "merge_base": "951427b",
+  "base_sha": "5735857",
+  "merge_base": "5735857",
   "dirty_files": [".python-version"],
   "included_files": [
-    "docs/sleipnir/design-issue-93-openai-compatible.md",
-    "src/why/_backends/openai_compatible.py",
-    "src/why/_backends/__init__.py",
-    "src/why/llm.py",
-    "tests/test_openai_compatible_backend.py",
-    "tests/test_llm.py",
-    "pyproject.toml",
-    "uv.lock"
+    "docs/sleipnir/design-issue-94-auto-shrink.md",
+    "src/why/synth.py",
+    "tests/test_shrink.py",
+    "tests/test_synth.py",
+    "README.md"
   ],
   "excluded_files": [".python-version"],
-  "issue": 93,
-  "design_doc": "docs/sleipnir/design-issue-93-openai-compatible.md",
+  "issue": 94,
+  "design_doc": "docs/sleipnir/design-issue-94-auto-shrink.md",
   "phase": "review"
 }

--- a/src/why/llm.py
+++ b/src/why/llm.py
@@ -118,6 +118,9 @@ class LLMClient:
       LM Studio, vLLM, TGI, …). Requires ``WHY_LLM_BASE_URL`` (e.g.
       ``http://localhost:11434/v1``). ``WHY_LLM_API_KEY`` is optional; defaults
       to ``"not-needed"`` for servers that do not require authentication.
+
+    After construction, ``self.provider`` holds the resolved provider string so
+    callers can branch on it without re-reading env vars.
     """
 
     def __init__(
@@ -129,6 +132,7 @@ class LLMClient:
 
         # Resolve provider: param → env var → default "groq"
         resolved_provider = provider or os.getenv("WHY_LLM_PROVIDER") or "groq"
+        self.provider = resolved_provider
 
         if resolved_provider == "groq":
             # Read the API key from the environment at construction time so

--- a/src/why/synth.py
+++ b/src/why/synth.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 import urllib.parse
+from dataclasses import replace
 from pathlib import Path
 
 import click
@@ -36,6 +38,103 @@ _LINE_WINDOW = 20
 
 _COST_PER_1K_TOKENS = 0.0008  # llama-3.3-70b Groq approximate rate
 _DEEP_COST_WARN_THRESHOLD = 0.50
+
+_MAX_DIFF_LINES = 80
+_CTX_HEADROOM = 0.85
+_DEFAULT_CTX_OPENAI_COMPAT = 4096
+
+
+def _estimate_tokens(text: str) -> int:
+    """Cheap token estimate: chars/4. Good enough — the budget reserves 15% headroom."""
+    return len(text) // 4
+
+
+def _shrink_for_budget(
+    commits: list[CommitWithPR],
+    current_code: str,
+    system_prompt: str,
+    target_tokens: int,
+) -> tuple[list[CommitWithPR], int, int]:
+    """Shrink commits to fit `target_tokens` budget for context-constrained models.
+
+    Strategy:
+      1. Truncate any diff longer than 80 lines to first 80 + sentinel.
+      2. Drop oldest commits (commits[0] first) until total estimated
+         tokens fit `target_tokens * 0.85` (15% headroom for the model's reply).
+
+    Returns: (shrunk_commits, dropped_count, truncated_count).
+
+    `commits` is expected to be sorted oldest-first (synthesize_why sorts this way).
+    """
+    truncated = 0
+    new_commits: list[CommitWithPR] = []
+    for c in commits:
+        lines = c.diff.splitlines()
+        if len(lines) > _MAX_DIFF_LINES:
+            dropped_lines = len(lines) - _MAX_DIFF_LINES
+            new_diff = (
+                "\n".join(lines[:_MAX_DIFF_LINES])
+                + f"\n... [truncated {dropped_lines} lines]"
+            )
+            c = replace(c, diff=new_diff)
+            truncated += 1
+        new_commits.append(c)
+
+    headroom = int(target_tokens * _CTX_HEADROOM)
+    fixed = _estimate_tokens(system_prompt) + _estimate_tokens(current_code)
+    budget = headroom - fixed
+
+    def _commit_cost(c: CommitWithPR) -> int:
+        return (
+            _estimate_tokens(c.diff)
+            + _estimate_tokens(c.commit.subject)
+            + _estimate_tokens(c.pr_body or "")
+            + _estimate_tokens(c.pr_title or "")
+        )
+
+    dropped = 0
+    total = sum(_commit_cost(c) for c in new_commits)
+    while new_commits and total > budget:
+        total -= _commit_cost(new_commits[0])
+        new_commits.pop(0)
+        dropped += 1
+
+    return new_commits, dropped, truncated
+
+
+def _resolve_max_ctx(provider: str) -> int | None:
+    """Resolve effective WHY_LLM_MAX_CTX target.
+
+    Resolution rules:
+      - WHY_LLM_MAX_CTX set to a positive integer → return that int.
+      - WHY_LLM_MAX_CTX set to "0" → return None (explicit disable).
+      - WHY_LLM_MAX_CTX unset:
+          - provider == "openai-compatible" → return _DEFAULT_CTX_OPENAI_COMPAT (default).
+          - Otherwise → return None.
+      - WHY_LLM_MAX_CTX set to a negative integer or non-integer string → return None
+        and log a single warning via the existing `_log` logger; do NOT raise.
+    """
+    raw = os.environ.get("WHY_LLM_MAX_CTX")
+
+    if raw is None:
+        if provider == "openai-compatible":
+            return _DEFAULT_CTX_OPENAI_COMPAT
+        return None
+
+    try:
+        value = int(raw)
+    except ValueError:
+        _log.warning("WHY_LLM_MAX_CTX=%r is not a valid integer; ignoring", raw)
+        return None
+
+    if value == 0:
+        return None  # explicit disable
+
+    if value < 0:
+        _log.warning("WHY_LLM_MAX_CTX=%d is negative; ignoring", value)
+        return None
+
+    return value
 
 
 def _estimate_prompt_cost(system: str, messages: list[Message]) -> float:
@@ -192,6 +291,8 @@ def synthesize_why(
         key_commits = capped
     else:
         key_commits = history if len(history) < 3 else select_key_commits(history, prs)
+        if max_commits is not None:
+            key_commits = key_commits[:max_commits]
 
     # Sort oldest-first so the LLM sees chronological order regardless of path.
     key_commits = sorted(key_commits, key=lambda c: c.date)
@@ -249,9 +350,25 @@ def synthesize_why(
             )
         )
 
-    messages = build_why_prompt(target, current_code, commits_with_prs, brief=brief)
     repo_url = _get_repo_url(repo)
     system_prompt = build_system_prompt(repo_url)
+
+    target_ctx = _resolve_max_ctx(llm.provider)
+    if target_ctx is not None:
+        user_set = os.getenv("WHY_LLM_MAX_CTX") is not None
+        commits_with_prs, dropped, truncated = _shrink_for_budget(
+            commits_with_prs, current_code, system_prompt, target_ctx
+        )
+        if dropped or truncated:
+            msg = (
+                f"⚠ Auto-shrunk to fit context budget: dropped {dropped} commit(s), "
+                f"truncated {truncated} diff(s)."
+            )
+            if not user_set:
+                msg += " Set WHY_LLM_MAX_CTX=0 to disable."
+            click.echo(msg, err=True)
+
+    messages = build_why_prompt(target, current_code, commits_with_prs, brief=brief)
 
     if deep:
         estimated_cost = _estimate_prompt_cost(system_prompt, messages)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,51 @@
+"""Shared test helpers for building Commit and CommitWithPR fixtures."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from why.commit import Commit
+from why.prompts import CommitWithPR
+
+_FIXED_DATE = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+
+
+def make_commit(
+    sha: str,
+    subject: str = "some commit message",
+    date: datetime | None = None,
+    author_name: str = "Test Author",
+    author_email: str = "test@example.com",
+    body: str = "",
+    additions: int = 0,
+    deletions: int = 0,
+) -> Commit:
+    """Return a minimal Commit suitable for testing."""
+    return Commit(
+        sha=sha,
+        author_name=author_name,
+        author_email=author_email,
+        date=date if date is not None else _FIXED_DATE,
+        subject=subject,
+        body=body,
+        parents=(),
+        additions=additions,
+        deletions=deletions,
+    )
+
+
+def make_cwpr(
+    sha: str,
+    diff: str = "",
+    subject: str = "some commit message",
+    pr_title: str | None = None,
+    pr_body: str | None = None,
+    date: datetime | None = None,
+) -> CommitWithPR:
+    """Return a CommitWithPR suitable for testing."""
+    return CommitWithPR(
+        commit=make_commit(sha, subject=subject, date=date),
+        diff=diff,
+        pr_title=pr_title,
+        pr_body=pr_body,
+    )

--- a/tests/test_shrink.py
+++ b/tests/test_shrink.py
@@ -1,0 +1,227 @@
+"""Tests for _estimate_tokens and _shrink_for_budget pure helpers in why.synth.
+
+Written BEFORE implementation (TDD red-green-refactor).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from tests._helpers import make_cwpr as _make_cwpr
+from why.synth import _estimate_tokens, _resolve_max_ctx, _shrink_for_budget
+
+# ---------------------------------------------------------------------------
+# _estimate_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_tokens_basic() -> None:
+    assert _estimate_tokens("x" * 100) == 25
+
+
+# ---------------------------------------------------------------------------
+# _shrink_for_budget
+# ---------------------------------------------------------------------------
+
+
+def test_shrink_no_op_when_under_budget() -> None:
+    """3 small commits with a generous budget → no drops, no truncations."""
+    commits = [
+        _make_cwpr("aaa", diff="short diff"),
+        _make_cwpr("bbb", diff="another short diff"),
+        _make_cwpr("ccc", diff="yet another short diff"),
+    ]
+    system_prompt = "tiny system"
+    current_code = "tiny code"
+    # Very large budget — nothing should be dropped or truncated
+    target_tokens = 100_000
+
+    shrunk, dropped, truncated = _shrink_for_budget(
+        commits, current_code, system_prompt, target_tokens
+    )
+
+    assert len(shrunk) == 3
+    assert dropped == 0
+    assert truncated == 0
+
+
+def test_shrink_drops_oldest_first() -> None:
+    """5 commits sorted oldest→newest; tight budget that fits ~3 → first 2 dropped."""
+    # Each diff is 400 chars ≈ 100 tokens; message ≈ 5 tokens.
+    # 5 commits * ~105 tokens each = ~525 tokens from commits alone.
+    # We want a budget that holds ~3 commits. Set system+code to near-zero
+    # and target_tokens so that headroom ≈ 320 tokens (fits 3 * ~105 but not 5).
+    diff = "a" * 400  # 100 tokens
+    commits = [_make_cwpr(f"commit{i}", diff=diff, subject="msg") for i in range(5)]
+
+    # headroom = int(380 * 0.85) ≈ 323 tokens
+    # fixed ≈ 0 (empty system + code)
+    # budget ≈ 323; each commit costs ~100 tokens → fits 3, not 5
+    target_tokens = 380
+
+    shrunk, dropped, truncated = _shrink_for_budget(
+        commits, "", "", target_tokens
+    )
+
+    assert dropped == 2
+    assert truncated == 0
+    assert len(shrunk) == 3
+    # Oldest two should be gone; remaining are commits[2], commits[3], commits[4]
+    assert [c.commit.sha for c in shrunk] == ["commit2", "commit3", "commit4"]
+
+
+def test_shrink_truncates_long_diffs() -> None:
+    """A commit with 200-line diff → truncated to 80 lines + sentinel."""
+    diff_lines = [f"line {i}" for i in range(200)]
+    diff = "\n".join(diff_lines)
+    commits = [_make_cwpr("sha1", diff=diff)]
+
+    # Very large budget so no dropping happens
+    shrunk, dropped, truncated = _shrink_for_budget(
+        commits, "", "", target_tokens=100_000
+    )
+
+    assert dropped == 0
+    assert truncated == 1
+    assert len(shrunk) == 1
+
+    result_diff = shrunk[0].diff
+    result_lines = result_diff.splitlines()
+    # 80 content lines + 1 sentinel line
+    assert len(result_lines) == 81
+    assert result_lines[80] == "... [truncated 120 lines]"
+    assert result_lines[0] == diff_lines[0]
+    assert result_lines[79] == diff_lines[79]
+
+
+def test_shrink_truncates_then_drops() -> None:
+    """Commits with long diffs AND total over budget → both truncation and dropping occur."""
+    # 4 commits, each with a 200-line diff.  After truncation each diff = first 80 lines + sentinel.
+    _TRUNCATED_LINES = 80
+    _SENTINEL_DROPPED = 120  # 200 - 80
+    _TOTAL_INPUT_LINES = 200
+
+    diff_lines = [f"line {i}" for i in range(_TOTAL_INPUT_LINES)]
+    diff = "\n".join(diff_lines)
+    commits = [_make_cwpr(f"sha{i}", diff=diff) for i in range(4)]
+
+    # Compute per-commit cost exactly to choose a deterministic target_tokens.
+    # _estimate_tokens(text) = len(text) // 4
+    sentinel = f"\n... [truncated {_SENTINEL_DROPPED} lines]"
+    truncated_diff = "\n".join(diff_lines[:_TRUNCATED_LINES]) + sentinel
+    expected_diff_tokens = len(truncated_diff) // 4  # 163
+    # Default subject in _make_cwpr is "some commit message" (19 chars → 4 tokens)
+    _DEFAULT_SUBJECT = "some commit message"
+    expected_subject_tokens = len(_DEFAULT_SUBJECT) // 4  # 4
+    per_commit_tokens = expected_diff_tokens + expected_subject_tokens  # 167
+
+    # headroom = int(target * 0.85); we want headroom to fit exactly 2 commits (not 3).
+    # 2 * 167 = 334; headroom must be > 334 to keep 2 but < 3*167=501.
+    # target = ceil((2 * per_commit_tokens + 1) / 0.85) = 395 → headroom = 335.
+    import math
+    target_tokens = math.ceil((2 * per_commit_tokens + 1) / 0.85)  # 395
+
+    shrunk, dropped, truncated = _shrink_for_budget(
+        commits, "", "", target_tokens
+    )
+
+    # Every commit had a >80-line diff, so all 4 were truncated.
+    assert truncated == 4
+    # Budget fits 2 commits → 2 oldest are dropped.
+    assert dropped == 2
+    assert len(shrunk) == 2
+    # Newest 2 commits are kept (sha2 and sha3; sha0 and sha1 were dropped).
+    assert [c.commit.sha for c in shrunk] == ["sha2", "sha3"]
+
+
+def test_shrink_empty_commits() -> None:
+    """Empty input → returns empty list with (0, 0) counts."""
+    shrunk, dropped, truncated = _shrink_for_budget([], "", "", target_tokens=1000)
+
+    assert shrunk == []
+    assert dropped == 0
+    assert truncated == 0
+
+
+def test_shrink_handles_negative_budget() -> None:
+    """When system+code alone exceed target * 0.85, all commits are dropped."""
+    # Each "word" is 4 chars → 1 token; 10000 chars = 2500 tokens
+    large_system = "x" * 10_000   # 2500 tokens
+    large_code = "y" * 10_000     # 2500 tokens
+    # total fixed = 5000 tokens; headroom = int(1000 * 0.85) = 850; budget = 850 - 5000 = -4150
+
+    commits = [_make_cwpr(f"sha{i}", diff="small diff") for i in range(3)]
+
+    shrunk, dropped, _truncated = _shrink_for_budget(
+        commits, large_code, large_system, target_tokens=1000
+    )
+
+    assert shrunk == []
+    assert dropped == 3
+
+
+# ---------------------------------------------------------------------------
+# _resolve_max_ctx
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_explicit_positive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WHY_LLM_MAX_CTX=2048 → returns 2048."""
+    monkeypatch.setenv("WHY_LLM_MAX_CTX", "2048")
+    assert _resolve_max_ctx("groq") == 2048
+
+
+def test_resolve_explicit_zero_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WHY_LLM_MAX_CTX=0 → returns None (explicit disable)."""
+    monkeypatch.setenv("WHY_LLM_MAX_CTX", "0")
+    assert _resolve_max_ctx("groq") is None
+
+
+def test_resolve_unset_openai_compatible_defaults_4096(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WHY_LLM_MAX_CTX unset, provider=openai-compatible → returns 4096."""
+    monkeypatch.delenv("WHY_LLM_MAX_CTX", raising=False)
+    assert _resolve_max_ctx("openai-compatible") == 4096
+
+
+def test_resolve_unset_groq_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WHY_LLM_MAX_CTX unset, provider=groq → returns None."""
+    monkeypatch.delenv("WHY_LLM_MAX_CTX", raising=False)
+    assert _resolve_max_ctx("groq") is None
+
+
+def test_resolve_unset_provider_unset_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WHY_LLM_MAX_CTX unset, provider=groq → returns None."""
+    monkeypatch.delenv("WHY_LLM_MAX_CTX", raising=False)
+    assert _resolve_max_ctx("groq") is None
+
+
+def test_resolve_explicit_overrides_provider_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WHY_LLM_MAX_CTX=8192, provider=openai-compatible → returns 8192."""
+    monkeypatch.setenv("WHY_LLM_MAX_CTX", "8192")
+    assert _resolve_max_ctx("openai-compatible") == 8192
+
+
+def test_resolve_invalid_value_returns_none_and_warns(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """WHY_LLM_MAX_CTX=abc → returns None, emits a warning."""
+    monkeypatch.setenv("WHY_LLM_MAX_CTX", "abc")
+    with caplog.at_level(logging.WARNING, logger="why.synth"):
+        result = _resolve_max_ctx("groq")
+    assert result is None
+    assert len(caplog.records) >= 1
+    assert caplog.records[0].levelno == logging.WARNING
+
+
+def test_resolve_negative_value_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WHY_LLM_MAX_CTX=-100 → returns None."""
+    monkeypatch.setenv("WHY_LLM_MAX_CTX", "-100")
+    assert _resolve_max_ctx("groq") is None
+
+
+def test_resolve_empty_string_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WHY_LLM_MAX_CTX="" → returns None (empty string treated as not-a-valid-integer)."""
+    monkeypatch.setenv("WHY_LLM_MAX_CTX", "")
+    assert _resolve_max_ctx("openai-compatible") is None

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests._helpers import make_commit as _make_commit
 from why.commit import Commit
 from why.llm import LLMClient
 from why.symbols import SymbolNotFoundError
@@ -170,19 +171,6 @@ class TestResolveLineRangeFileOnly:
 # ---------------------------------------------------------------------------
 
 # Fixture helpers
-
-def _make_commit(sha: str) -> Commit:
-    """Return a minimal Commit with the given SHA, suitable for testing."""
-    return Commit(
-        sha=sha,
-        author_name="Alice",
-        author_email="alice@example.com",
-        date=datetime(2024, 1, 1, tzinfo=timezone.utc),  # noqa: UP017 — datetime.UTC absent in 3.11.0b1
-        subject=f"commit {sha[:7]}",
-        body="",
-        parents=(),
-    )
-
 
 # Patch targets — all patched on the synth module so the function uses them
 _PATCH_FILE_HISTORY = "why.synth.get_file_history"
@@ -963,6 +951,7 @@ class TestSynthesizeWhyTwoPass:
     def test_synthesize_why_two_pass_makes_second_llm_call(self, tmp_path: Path) -> None:
         commits, _f, target = self._make_setup(tmp_path)
         mock_llm = MagicMock(spec=LLMClient)
+        mock_llm.provider = "groq"
         mock_llm.complete.side_effect = [
             "first pass output",
             "## 🔍 Grounding Check\n\n| Claim | Verdict |\n|---|---|\n| foo | supported |",
@@ -988,6 +977,7 @@ class TestSynthesizeWhyTwoPass:
             "## 🔍 Grounding Check\n\n| Claim | Verdict |\n|---|---|\n| foo | supported |"
         )
         mock_llm = MagicMock(spec=LLMClient)
+        mock_llm.provider = "groq"
         mock_llm.complete.side_effect = ["first pass output", grounding_output]
 
         with (
@@ -1007,6 +997,7 @@ class TestSynthesizeWhyTwoPass:
     def test_synthesize_why_single_pass_unchanged(self, tmp_path: Path) -> None:
         commits, _f, target = self._make_setup(tmp_path)
         mock_llm = MagicMock(spec=LLMClient)
+        mock_llm.provider = "groq"
         mock_llm.complete.return_value = "single pass output"
 
         with (
@@ -1029,6 +1020,7 @@ class TestSynthesizeWhyTwoPass:
         commits, _f, target = self._make_setup(tmp_path)
         first_pass_text = "first pass output with timeline"
         mock_llm = MagicMock(spec=LLMClient)
+        mock_llm.provider = "groq"
         mock_llm.complete.side_effect = [
             first_pass_text,
             "## 🔍 Grounding Check\n\nok",
@@ -1625,3 +1617,161 @@ class TestSynthesizeWhyBriefFlag:
 
         call_kwargs = mock_build_prompt.call_args.kwargs
         assert call_kwargs.get("brief") is False
+
+
+# ---------------------------------------------------------------------------
+# Stride 3: shrink integration tests — warning emission and call-through
+# ---------------------------------------------------------------------------
+
+_PATCH_SHRINK = "why.synth._shrink_for_budget"
+_PATCH_RESOLVE_MAX_CTX = "why.synth._resolve_max_ctx"
+
+
+class TestSynthesizeWhyShrinkIntegration:
+    """synthesize_why wires _shrink_for_budget and emits the user-facing warning."""
+
+    def _make_setup(self, tmp_path: Path, n: int = 3):
+        commits = [_make_commit(f"shrk{i:04d}" * 10) for i in range(n)]
+        f = _make_py_file(tmp_path, "foo.py", "x = 1\n")
+        target = Target(file=f)
+        return commits, f, target
+
+    def test_synthesize_no_shrink_when_max_ctx_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """provider=groq, WHY_LLM_MAX_CTX unset → _resolve_max_ctx returns None →
+        no shrink call, no warning, full commit list reaches build_why_prompt."""
+        monkeypatch.delenv("WHY_LLM_MAX_CTX", raising=False)
+
+        commits, _f, target = self._make_setup(tmp_path, n=3)
+        llm = MagicMock()
+        llm.provider = "groq"
+        llm.complete.return_value = "answer"
+        captured: list = []
+
+        def fake_build_prompt(t, code, cwprs, **kwargs):
+            captured.extend(cwprs)
+            return [MagicMock()]
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT, return_value=commits),
+            patch(_PATCH_DIFF, return_value="small diff"),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, side_effect=fake_build_prompt),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+        ):
+            synthesize_why(target, tmp_path, llm)
+
+        # All 3 commits must reach build_why_prompt unchanged
+        assert len(captured) == 3
+        # No warning emitted to stderr
+        err = capsys.readouterr().err
+        assert "Auto-shrunk" not in err
+
+    def test_synthesize_emits_warning_when_shrink_fires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """WHY_LLM_MAX_CTX=100 (tiny) → shrink fires → warning with
+        'Auto-shrunk to fit context budget' but WITHOUT
+        'Set WHY_LLM_MAX_CTX=0 to disable.' (user explicitly set the env)."""
+        monkeypatch.setenv("WHY_LLM_MAX_CTX", "100")
+
+        commits, _f, target = self._make_setup(tmp_path, n=3)
+        llm = MagicMock()
+        llm.provider = "groq"
+        llm.complete.return_value = "answer"
+
+        # Fake shrink: drops 2, truncates 1
+        from why.prompts import CommitWithPR as CwPR
+        remaining = [
+            CwPR(commit=commits[0], diff="d", pr_body=None, pr_number=None, pr_title=None)
+        ]
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT, return_value=commits),
+            patch(_PATCH_DIFF, return_value="diff text"),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+            patch(_PATCH_SHRINK, return_value=(remaining, 2, 1)),
+        ):
+            synthesize_why(target, tmp_path, llm)
+
+        err = capsys.readouterr().err
+        assert "Auto-shrunk to fit context budget" in err
+        assert "dropped 2 commit(s)" in err
+        assert "truncated 1 diff(s)" in err
+        # User explicitly set WHY_LLM_MAX_CTX → disable hint must NOT appear
+        assert "Set WHY_LLM_MAX_CTX=0 to disable." not in err
+
+    def test_synthesize_emits_warning_with_disable_hint_when_default_kicks_in(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """llm.provider=openai-compatible + WHY_LLM_MAX_CTX unset → _resolve_max_ctx
+        returns 4096 (default) → shrink fires → warning includes 'Set WHY_LLM_MAX_CTX=0 to disable.'
+        because the user did NOT explicitly set WHY_LLM_MAX_CTX."""
+        monkeypatch.delenv("WHY_LLM_MAX_CTX", raising=False)
+
+        commits, _f, target = self._make_setup(tmp_path, n=3)
+        llm = MagicMock()
+        llm.provider = "openai-compatible"
+        llm.complete.return_value = "answer"
+
+        from why.prompts import CommitWithPR as CwPR
+        remaining = [
+            CwPR(commit=commits[0], diff="d", pr_body=None, pr_number=None, pr_title=None)
+        ]
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT, return_value=commits),
+            patch(_PATCH_DIFF, return_value="diff text"),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+            patch(_PATCH_SHRINK, return_value=(remaining, 1, 0)),
+        ):
+            synthesize_why(target, tmp_path, llm)
+
+        err = capsys.readouterr().err
+        assert "Auto-shrunk to fit context budget" in err
+        # Default kicked in (WHY_LLM_MAX_CTX was unset) → disable hint MUST appear
+        assert "Set WHY_LLM_MAX_CTX=0 to disable." in err
+
+    def test_synthesize_no_warning_when_shrink_no_op(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """WHY_LLM_MAX_CTX=100000 (huge) → shrink is called but drops=0 and truncated=0
+        → no warning emitted."""
+        monkeypatch.setenv("WHY_LLM_MAX_CTX", "100000")
+
+        commits, _f, target = self._make_setup(tmp_path, n=2)
+        llm = MagicMock()
+        llm.provider = "groq"
+        llm.complete.return_value = "answer"
+
+        from why.prompts import CommitWithPR as CwPR
+        full_list = [
+            CwPR(commit=c, diff="small diff", pr_body=None, pr_number=None, pr_title=None)
+            for c in commits
+        ]
+
+        with (
+            patch(_PATCH_FILE_HISTORY, return_value=commits),
+            patch(_PATCH_SELECT, return_value=commits),
+            patch(_PATCH_DIFF, return_value="small diff"),
+            patch(_PATCH_EXTRACT_CODE, return_value="code"),
+            patch(_PATCH_RESOLVE_RANGE, return_value=None),
+            patch(_PATCH_BUILD_PROMPT, return_value=[MagicMock()]),
+            patch(_PATCH_GET_REPO_URL, return_value=None),
+            patch(_PATCH_SHRINK, return_value=(full_list, 0, 0)),
+        ):
+            synthesize_why(target, tmp_path, llm)
+
+        err = capsys.readouterr().err
+        assert "Auto-shrunk" not in err


### PR DESCRIPTION
## Related Links

Closes #94. Builds on #93 (openai-compatible provider). Part of the local-LLM series #93–#97.

## What

Adds auto-shrink for the prompt sent to context-constrained LLM providers. New env var `WHY_LLM_MAX_CTX`:

- positive int → use as token budget
- `0` → disable
- unset, provider=`openai-compatible` → defaults to `4096`
- unset, provider=`groq` → no shrinking (existing behavior)

When shrinking fires, drops oldest commits and truncates each remaining diff to 80 lines. Single stderr warning: `⚠ Auto-shrunk to fit context budget: dropped N commit(s), truncated M diff(s).`

## Why

Local 3B-class models (qwen2.5:3b on Ollama) have small context windows — Ollama's default `num_ctx` is 2048. `why`'s real prompts run 8K–20K tokens. Without shrinking, users see truncated mid-sentence answers or model regression. The user-facing fix is auto-shrink with a visible warning, not silent failure.

## How

- New helpers in `src/why/synth.py`: `_estimate_tokens` (chars/4), `_shrink_for_budget` (truncate diffs to 80 lines + drop oldest in O(n)), `_resolve_max_ctx(provider)` (env + provider-aware default).
- `LLMClient.provider` attribute exposes the resolved provider so synth doesn't double-read env (avoids the constructor-arg vs env mismatch).
- Wire-in inside `synthesize_why` between commit assembly and prompt build; reorders `system_prompt` build to happen earlier so it's available for the budget calc.
- `--max-commits` now applies in the non-deep path before shrink (was a pre-existing gap surfaced by review).
- Magic numbers extracted to module constants (`_MAX_DIFF_LINES`, `_CTX_HEADROOM`, `_DEFAULT_CTX_OPENAI_COMPAT`).
- Shared `make_commit`/`make_cwpr` helpers extracted to `tests/_helpers.py`.

## Test Steps

- [ ] `uv run pytest` — 353 passing (+19 net for this PR).
- [ ] `uv run ruff check && uv run mypy src/why` — clean.
- [ ] Live smoke: `WHY_LLM_PROVIDER=openai-compatible WHY_LLM_BASE_URL=http://localhost:11434/v1 why src/why/synth.py:144 --model qwen2.5:3b` → expect either no warning (small file) or the auto-shrunk warning, no truncated answer.
- [ ] Escape hatch: same command with `WHY_LLM_MAX_CTX=0` → no shrink, no warning.

## Other Notes

Out of scope (tracked separately):
- `num_ctx` plumbing into the openai-compatible request body — #95.
- Citation guardrails for weaker models — #96.
- Relevance-ranked drop order (currently oldest-first) — future issue.
- Including dropped commit SHAs in the warning text — UX nice-to-have.

The 4096 default is higher than Ollama's stock 2048 `num_ctx`. README's auto-shrink section explicitly tells users to bump `num_ctx` (Modelfile or per-request) to match.