### PR TITLE
feat: auto-enable strict citations for local providers (#96)

### DIFF
--- a/docs/sleipnir/design-issue-96-strict-citations-local.md
+++ b/docs/sleipnir/design-issue-96-strict-citations-local.md
@@ -1,0 +1,93 @@
+# Design — Issue #96: Auto-enable strict citation validation for local providers
+
+**Issue:** [#96](https://github.com/tarungulati1988/why/issues/96)
+**Branch:** `sleipnir/issue-96-strict-citations-local`
+**Depends on:** #93 (provider attr), #94/#95 (provider plumbing) — all merged
+**Scope:** small (~1-2h)
+
+## Problem
+
+3B-class local models hallucinate SHAs and PR numbers more often than 70B Groq. The pipeline already has `validate_citations(..., strict=True)` that raises on hallucinations, but it's opt-in and never wired into the CLI. Default is `strict=False` (warn-only), which produces output that *looks* grounded but isn't.
+
+We want strict citations auto-on whenever provider is `openai-compatible`, with an explicit opt-out.
+
+## Decisions
+
+### 1. New CLI flag `--no-strict-citations`
+
+Boolean opt-out. Default unset. Resolution:
+
+```python
+strict = (llm.provider == "openai-compatible") and not no_strict_citations
+```
+
+groq stays warn-only regardless of flag (matches current behavior; flag is a no-op there). The flag is opt-out (rather than positive `--strict-citations`) because the auto-on behavior is the new default for local; users only need to flip it off.
+
+### 2. Typed exception `CitationError`
+
+`validate_citations` currently raises `ValueError("citation validation failed: N issues")` in strict mode. Replace with a typed `CitationError(ValueError)` that carries `issues: list[ValidationIssue]` so the CLI can render a friendly message naming the offending value.
+
+```python
+class CitationError(ValueError):
+    def __init__(self, issues: list[ValidationIssue]) -> None:
+        self.issues = issues
+        # Use first issue for primary message; full list available via .issues
+        first = issues[0]
+        super().__init__(f"unknown {first.kind.removeprefix('unknown_')}: {first.value}")
+```
+
+`ValueError` subclass keeps backwards compatibility for any callers (tests) currently doing `except ValueError`.
+
+### 3. Friendly CLI error
+
+Wrap `CitationError` in `cli.py`:
+
+```python
+except CitationError as exc:
+    click.echo(
+        f"⚠ Local model hallucinated citation: {exc}. "
+        f"Try --no-strict-citations to allow, or switch to a larger model.",
+        err=True,
+    )
+    sys.exit(1)
+```
+
+The `except (LLMError, GitError, SymbolNotFoundError)` block stays — `CitationError` gets its own clause *before* it (more specific).
+
+### 4. No change to `synthesize_why` signature
+
+`strict: bool = False` already exists. CLI just passes the resolved value. Keeps the synth API stable.
+
+## File layout
+
+```
+src/why/citations.py    Add CitationError class; raise it instead of ValueError
+src/why/cli.py          Add --no-strict-citations flag; resolve strict; catch CitationError
+tests/test_citations.py Extend: CitationError raised, carries issues
+tests/test_cli.py       New tests: auto-on for openai-compatible, off for groq, opt-out works,
+                        friendly error printed
+```
+
+## Acceptance
+
+- `provider=openai-compatible`, no flag → `strict=True` passed to `synthesize_why`.
+- `provider=openai-compatible`, `--no-strict-citations` → `strict=False`.
+- `provider=groq` → `strict=False` regardless of flag.
+- `CitationError` raised in strict mode, carries `issues` list.
+- CLI prints friendly message + exit 1 on `CitationError`.
+
+## Strides
+
+```
+Stride 1: CitationError typed exception | test: tests/test_citations.py | impl: src/why/citations.py | depends: []
+Stride 2: --no-strict-citations flag + auto-on resolution | test: tests/test_cli.py | impl: src/why/cli.py | depends: [1]
+Stride 3: Friendly error wrapping | test: tests/test_cli.py | impl: src/why/cli.py | depends: [1, 2]
+```
+
+Wave 1: Stride 1. Wave 2: Strides 2+3 (same file, dispatched sequentially).
+
+## Out of scope
+
+- Retry-with-feedback when citation hallucinated (issue's "interesting follow-up").
+- Citation grounding for `--verify` two-pass.
+- Per-issue partial recovery (just fail loudly).

--- a/docs/sleipnir/state.json
+++ b/docs/sleipnir/state.json
@@ -1,17 +1,17 @@
 {
-  "branch": "sleipnir/issue-95-num-ctx-ollama",
+  "branch": "sleipnir/issue-96-strict-citations-local",
   "base_ref": "origin/main",
-  "base_sha": "43a54d3",
-  "merge_base": "43a54d3",
+  "base_sha": "c2af530",
+  "merge_base": "c2af530",
   "dirty_files": [".python-version"],
   "included_files": [
-    "src/why/_backends/openai_compatible.py",
-    "src/why/llm.py",
-    "tests/test_llm.py",
-    "README.md"
+    "src/why/citations.py",
+    "src/why/cli.py",
+    "tests/test_citations.py",
+    "tests/test_cli.py"
   ],
   "excluded_files": [".python-version"],
-  "issue": 95,
-  "design_doc": "docs/sleipnir/design-issue-95-num-ctx-ollama.md",
-  "phase": "review"
+  "issue": 96,
+  "design_doc": "docs/sleipnir/design-issue-96-strict-citations-local.md",
+  "phase": "execution"
 }

--- a/src/why/citations.py
+++ b/src/why/citations.py
@@ -20,6 +20,14 @@ class ValidationIssue:
     output_line: str # the full line from the LLM output that contained it
 
 
+class CitationError(ValueError):
+    """Raised by validate_citations when strict=True and issues are found."""
+
+    def __init__(self, issues: list[ValidationIssue]) -> None:
+        self.issues = issues
+        super().__init__(f"citation validation failed: {len(issues)} issues")
+
+
 def validate_citations(
     output: str,
     known_shas: set[str],
@@ -58,6 +66,6 @@ def validate_citations(
                     issues.append(ValidationIssue("unknown_pr", str(pr), safe_line))
 
     if strict and issues:
-        raise ValueError(f"citation validation failed: {len(issues)} issues")
+        raise CitationError(issues)
 
     return issues

--- a/src/why/cli.py
+++ b/src/why/cli.py
@@ -7,6 +7,7 @@ import click
 
 from why import __version__
 from why.cache import PRCache
+from why.citations import CitationError
 from why.git import GitError
 from why.github import GitHubClient, detect_github_token
 from why.llm import LLMClient, LLMError
@@ -79,6 +80,15 @@ ARGUMENTS:
     default=False,
     help="Disable local PR metadata cache and fetch fresh from GitHub.",
 )
+@click.option(
+    "--no-strict-citations",
+    is_flag=True,
+    default=False,
+    help=(
+        "Allow citations to SHAs/PRs not in the LLM's input context. "
+        "Strict mode is auto-enabled for local providers; this flag opts out."
+    ),
+)
 def main(
     target_spec: str,
     extra: str | None,
@@ -89,6 +99,7 @@ def main(
     deep: bool,
     max_commits: int | None,
     no_cache: bool,
+    no_strict_citations: bool,
 ) -> None:
     """Explain why code is the way it is via git history and LLM synthesis."""
     cwd = Path.cwd()
@@ -126,6 +137,7 @@ def main(
 
     try:
         llm = LLMClient(model)
+        strict = (llm.provider == "openai-compatible") and not no_strict_citations
         output = synthesize_why(
             target, cwd, llm,
             gh=gh_client,
@@ -134,7 +146,16 @@ def main(
             brief=brief,
             deep=deep,
             max_commits=max_commits,
+            strict=strict,
         )
+    except CitationError as exc:
+        first = exc.issues[0]
+        click.echo(
+            f"⚠ Local model hallucinated citation: {first.value}. "
+            f"Try --no-strict-citations to allow, or switch to a larger model.",
+            err=True,
+        )
+        sys.exit(1)
     except (LLMError, GitError, SymbolNotFoundError) as exc:
         click.echo(f"Error: {exc}", err=True)
         sys.exit(1)

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from why.citations import validate_citations
+from why.citations import CitationError, validate_citations
 
 # ---------------------------------------------------------------------------
 # Shared golden fixtures
@@ -183,3 +183,41 @@ def test_sha_check_skipped_when_known_shas_empty() -> None:
     output = f"Changed in {UNKNOWN_SHA} for reasons."
     issues = validate_citations(output, known_shas=set(), known_prs=set())
     assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# 12. strict=True raises CitationError (typed exception, not bare ValueError)
+# ---------------------------------------------------------------------------
+
+def test_strict_raises_citation_error() -> None:
+    """strict=True raises CitationError, not a bare ValueError."""
+    output = f"Commit {UNKNOWN_SHA} is suspicious."
+    with pytest.raises(CitationError):
+        validate_citations(output, {KNOWN_SHA_FULL}, set(), strict=True)
+
+
+# ---------------------------------------------------------------------------
+# 13. CitationError carries the issues list
+# ---------------------------------------------------------------------------
+
+def test_citation_error_carries_issues() -> None:
+    """Caught CitationError exposes .issues with the ValidationIssue objects."""
+    output = f"Commit {UNKNOWN_SHA} is suspicious."
+    with pytest.raises(CitationError) as exc_info:
+        validate_citations(output, {KNOWN_SHA_FULL}, set(), strict=True)
+    err = exc_info.value
+    assert len(err.issues) == 1
+    assert err.issues[0].kind == "unknown_sha"
+    assert err.issues[0].value == UNKNOWN_SHA
+
+
+# ---------------------------------------------------------------------------
+# 14. CitationError is a ValueError subclass (backwards compat)
+# ---------------------------------------------------------------------------
+
+def test_citation_error_is_value_error() -> None:
+    """CitationError is a subclass of ValueError for backwards compatibility."""
+    output = f"Commit {UNKNOWN_SHA} is suspicious."
+    with pytest.raises(CitationError) as exc_info:
+        validate_citations(output, {KNOWN_SHA_FULL}, set(), strict=True)
+    assert isinstance(exc_info.value, ValueError)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -720,3 +720,105 @@ def test_no_cache_flag_passes_pr_cache_none(existing_file: Path) -> None:
     assert result.exit_code == 0, result.output
     _, kwargs = mock_synth.call_args
     assert kwargs.get("pr_cache") is None
+
+
+# ---------------------------------------------------------------------------
+# --no-strict-citations flag tests (Strides 2 & 3)
+# ---------------------------------------------------------------------------
+
+
+def test_strict_auto_on_for_openai_compatible(existing_file: Path) -> None:
+    """provider=openai-compatible + no flag → synthesize_why called with strict=True."""
+    with (
+        patch("why.cli.Path") as mock_path_cls,
+        patch("why.cli.LLMClient") as mock_llm_cls,
+        patch("why.cli.synthesize_why", return_value="explanation") as mock_synth,
+    ):
+        mock_llm_instance = MagicMock()
+        mock_llm_instance.provider = "openai-compatible"
+        mock_llm_cls.return_value = mock_llm_instance
+        mock_path_cls.cwd.return_value = existing_file.parent
+
+        result = CliRunner().invoke(main, [str(existing_file)])
+
+    assert result.exit_code == 0, result.output
+    assert mock_synth.call_args.kwargs.get("strict") is True
+
+
+def test_strict_auto_off_for_groq(existing_file: Path) -> None:
+    """provider=groq + no flag → synthesize_why called with strict=False."""
+    with (
+        patch("why.cli.Path") as mock_path_cls,
+        patch("why.cli.LLMClient") as mock_llm_cls,
+        patch("why.cli.synthesize_why", return_value="explanation") as mock_synth,
+    ):
+        mock_llm_instance = MagicMock()
+        mock_llm_instance.provider = "groq"
+        mock_llm_cls.return_value = mock_llm_instance
+        mock_path_cls.cwd.return_value = existing_file.parent
+
+        result = CliRunner().invoke(main, [str(existing_file)])
+
+    assert result.exit_code == 0, result.output
+    assert mock_synth.call_args.kwargs.get("strict") is False
+
+
+def test_no_strict_citations_flag_opts_out(existing_file: Path) -> None:
+    """provider=openai-compatible + --no-strict-citations → strict=False."""
+    with (
+        patch("why.cli.Path") as mock_path_cls,
+        patch("why.cli.LLMClient") as mock_llm_cls,
+        patch("why.cli.synthesize_why", return_value="explanation") as mock_synth,
+    ):
+        mock_llm_instance = MagicMock()
+        mock_llm_instance.provider = "openai-compatible"
+        mock_llm_cls.return_value = mock_llm_instance
+        mock_path_cls.cwd.return_value = existing_file.parent
+
+        result = CliRunner().invoke(main, ["--no-strict-citations", str(existing_file)])
+
+    assert result.exit_code == 0, result.output
+    assert mock_synth.call_args.kwargs.get("strict") is False
+
+
+def test_no_strict_citations_no_op_for_groq(existing_file: Path) -> None:
+    """provider=groq + --no-strict-citations → strict=False (flag is no-op)."""
+    with (
+        patch("why.cli.Path") as mock_path_cls,
+        patch("why.cli.LLMClient") as mock_llm_cls,
+        patch("why.cli.synthesize_why", return_value="explanation") as mock_synth,
+    ):
+        mock_llm_instance = MagicMock()
+        mock_llm_instance.provider = "groq"
+        mock_llm_cls.return_value = mock_llm_instance
+        mock_path_cls.cwd.return_value = existing_file.parent
+
+        result = CliRunner().invoke(main, ["--no-strict-citations", str(existing_file)])
+
+    assert result.exit_code == 0, result.output
+    assert mock_synth.call_args.kwargs.get("strict") is False
+
+
+def test_citation_error_friendly_message(existing_file: Path) -> None:
+    """synthesize_why raises CitationError → friendly message, exit code 1."""
+    from why.citations import CitationError, ValidationIssue
+
+    fake_issue = ValidationIssue("unknown_sha", "abc1234", "some line")
+
+    with (
+        patch("why.cli.Path") as mock_path_cls,
+        patch("why.cli.LLMClient") as mock_llm_cls,
+        patch("why.cli.synthesize_why", side_effect=CitationError([fake_issue])),
+    ):
+        mock_llm_instance = MagicMock()
+        mock_llm_instance.provider = "openai-compatible"
+        mock_llm_cls.return_value = mock_llm_instance
+        mock_path_cls.cwd.return_value = existing_file.parent
+
+        result = CliRunner().invoke(main, [str(existing_file)])
+
+    assert result.exit_code == 1
+    # CliRunner mixes stderr into output by default; check combined output.
+    assert "Local model hallucinated citation" in result.output
+    assert "abc1234" in result.output  # offending SHA named in message
+    assert "--no-strict-citations" in result.output


### PR DESCRIPTION
## Related Links

- Closes #96
- Series: #93 (provider) → #94 (auto-shrink) → #95 (num_ctx) → **#96** → #97 (docs)

## What

Auto-enable strict citation validation when provider is `openai-compatible`. Adds:

- `CitationError(ValueError)` — typed exception carrying the `issues` list, raised by `validate_citations(strict=True)` instead of bare `ValueError` (backwards-compat: still a `ValueError`).
- `--no-strict-citations` CLI flag — opt-out. Default unset.
- Resolution: `strict = (llm.provider == "openai-compatible") and not no_strict_citations`. Groq stays warn-only.
- Friendly CLI error naming the offending SHA: `⚠ Local model hallucinated citation: <sha>. Try --no-strict-citations to allow, or switch to a larger model.`

## Why

3B-class local models hallucinate SHAs/PRs more often than 70B Groq. The pipeline already had a `strict=True` codepath that raises on hallucinations, but it was never wired into the CLI — default warn-only produces output that *looks* grounded but isn't. Auto-on for local closes the loop; explicit opt-out preserves the escape hatch.

## How

- `src/why/citations.py` — added `CitationError`; `validate_citations` now raises it.
- `src/why/cli.py` — new `--no-strict-citations` flag; resolve `strict` from `llm.provider`; catch `CitationError` and render friendly message before the generic `except` clause.
- 8 new tests (3 in `test_citations.py`, 5 in `test_cli.py`).

## Test Steps

- [x] `pytest -q` → 376 passed (+5)
- [x] `ruff check src/ tests/` → clean
- [x] `mypy src` → clean
- [x] Self-review caught one issue: friendly error originally embedded `{exc}` ("citation validation failed: N issues") — fixed to render `first.value` (the actual SHA) per AC; test updated to assert SHA appears.

## Other Notes

- Out of scope: retry-with-feedback on hallucination, `--verify` two-pass grounding, partial recovery.
- Design doc: `docs/sleipnir/design-issue-96-strict-citations-local.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)