### PR TITLE
chore: temporarily remove website/CNAME until www.why.ai is registered

### DIFF
--- a/website/CNAME
+++ b/website/CNAME
@@ -1,1 +1,0 @@
-www.why.ai


### PR DESCRIPTION
## Related Links

Follow-up to #104.

## What

Removes `website/CNAME` (contents: `www.why.ai`).

## Why

`www.why.ai` is not yet a registered domain — `dig +short NS why.ai` shows `ns{1,2}.sedoparking.com` (the domain is parked on Sedo, not under our DNS control). With `website/CNAME` present, every Pages deploy writes `CNAME` into `_site/`, which makes GitHub Pages issue a 301 redirect from `https://tarungulati1988.github.io/why/` to `http://www.why.ai/` — and that domain resolves to a parking page (HTTP 405). End result: the published docs site is unreachable until the domain is bought.

Removing the CNAME file lets the site serve directly from `https://tarungulati1988.github.io/why/` until the domain is registered.

## How

- `git rm website/CNAME` — single-file delete.
- No other changes. The Pages workflow (`.github/workflows/pages.yml`) and Jekyll config (`website/_config.yml`) are untouched.
- When the domain is registered and DNS points at GitHub: revert this commit (or recreate `website/CNAME` with `www.why.ai`) and add the registrar DNS records (CNAME `www` → `tarungulati1988.github.io.`, optionally A records on apex pointing at `185.199.108-111.153`).

## Test Steps

- [ ] After merge: `pages.yml` redeploys; `https://tarungulati1988.github.io/why/` serves the Jekyll site directly (no 301 redirect to `www.why.ai`).
- [ ] `gh api repos/tarungulati1988/why/pages | jq '.cname, .html_url'` returns `null` and `https://tarungulati1988.github.io/why/`.

## Other Notes

- Reversal is one revert commit. Don't forget the registrar DNS step before reverting.
- The `gh api -X PUT .../pages -f cname=` call already cleared the API-level CNAME setting; this PR removes the file-level CNAME so the next deploy doesn't re-apply it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)