### PR TITLE
fix(website): set baseurl=/why for project-pages hosting

### DIFF
--- a/website/_config.yml
+++ b/website/_config.yml
@@ -1,7 +1,7 @@
 title: why
 description: git blame tells you who. why tells you why.
-url: https://www.why.ai
-baseurl: ""
+url: https://tarungulati1988.github.io
+baseurl: "/why"
 
 remote_theme: just-the-docs/just-the-docs
 


### PR DESCRIPTION
## Related Links

Follow-up to #104, #105.

## What

`website/_config.yml`:
- `url: https://www.why.ai` → `https://tarungulati1988.github.io`
- `baseurl: ""` → `/why`

## Why

The site is currently served at `https://tarungulati1988.github.io/why/` (project pages). With `baseurl: ""`, just-the-docs generates asset URLs like `/assets/css/just-the-docs-default.css` — but those resolve to `https://tarungulati1988.github.io/assets/...` (404), not `https://tarungulati1988.github.io/why/assets/...` (200). Net effect: the page renders as raw unstyled HTML with a giant unsized SVG icon.

Verified:
```
curl -sI https://tarungulati1988.github.io/assets/css/just-the-docs-default.css     # 404
curl -sI https://tarungulati1988.github.io/why/assets/css/just-the-docs-default.css # 200
```

GitHub Pages serves project pages from `/<repo>/`, so for project pages `baseurl` MUST be `/<repo>` and `url` MUST be the github.io host. just-the-docs uses both to build asset and link URLs.

## How

- `url`: switched to the github.io host (this is where the site is actually served).
- `baseurl`: set to `/why` (matches the path prefix GitHub Pages uses for the `tarungulati1988/why` project page).
- When a custom domain is later added, both values flip back: `url: https://www.<custom>` and `baseurl: ""`.

## Test Steps

- [ ] After merge: `pages.yml` redeploys (~30s).
- [ ] `curl -s https://tarungulati1988.github.io/why/ | grep -oE 'href="[^"]+\.css"' | head -2` returns `/why/assets/css/...` (not `/assets/css/...`).
- [ ] Browser: site renders with sidebar, search box, and styled typography (no giant black SVG).

## Other Notes

- `permalink: pretty` and the in-page absolute links like `/install/` continue to work — Jekyll prefixes them with `baseurl` automatically when generating `<a href>`.
- No other config keys touched. `exclude:`, `plugins:`, search settings unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)